### PR TITLE
CAP-120:  Allow admins to limit which predefined calenders may appear wi...

### DIFF
--- a/src/main/java/org/jasig/portlet/calendar/dao/HibernateCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/HibernateCalendarSetDao.java
@@ -28,6 +28,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletSession;
 
 import org.jasig.portlet.calendar.CalendarSet;
+import org.jasig.portlet.calendar.PredefinedCalendarConfiguration;
 import org.jasig.portlet.calendar.UserDefinedCalendarConfiguration;
 import org.jasig.portlet.calendar.service.SessionSetupInitializationService;
 import org.springframework.beans.factory.annotation.Required;
@@ -54,21 +55,39 @@ public class HibernateCalendarSetDao implements ICalendarSetDao {
      */
     public CalendarSet<?> getCalendarSet(PortletRequest request) {
         
-        // Get the username from the portlet session.  This implementation
-        // assumes that the session initialization service is run at login time
-        PortletSession session = request.getPortletSession();
-        String username = (String) session.getAttribute(SessionSetupInitializationService.USERNAME_KEY);
-        
+        final String username = getUsername(request);
+                
         // retrieve a list of calendar configurations for this user
-        List<UserDefinedCalendarConfiguration> cals = calendarStore
+        final List<UserDefinedCalendarConfiguration> cals = calendarStore
             .getCalendarConfigurations(username);
         
-        Set<UserDefinedCalendarConfiguration> calendars = new HashSet<UserDefinedCalendarConfiguration>();
+        final Set<UserDefinedCalendarConfiguration> calendars = new HashSet<UserDefinedCalendarConfiguration>();
         calendars.addAll(cals);
         
-        CalendarSet<UserDefinedCalendarConfiguration> set = new CalendarSet<UserDefinedCalendarConfiguration>();
+        final CalendarSet<UserDefinedCalendarConfiguration> set = new CalendarSet<UserDefinedCalendarConfiguration>();
         set.setConfigurations(calendars);
         return set;
+    }
+
+    @Override
+    public List<PredefinedCalendarConfiguration> getAvailablePredefinedCalendarConfigurations(PortletRequest request) {
+
+        final String username = getUsername(request);
+
+        // For this ICalendarSetDao, the list is the unfiltered collection from CalendarStore...
+        return calendarStore.getPredefinedCalendarConfigurations(username, false);
+    }
+    
+    /*
+     * Implementation
+     */
+    
+    private String getUsername(PortletRequest request) {
+        // Get the username from the portlet session.  This implementation
+        // assumes that the session initialization service is run at login time
+        final PortletSession session = request.getPortletSession();
+        final String rslt = (String) session.getAttribute(SessionSetupInitializationService.USERNAME_KEY);
+        return rslt;
     }
 
 }

--- a/src/main/java/org/jasig/portlet/calendar/dao/ICalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/ICalendarSetDao.java
@@ -19,12 +19,17 @@
 
 package org.jasig.portlet.calendar.dao;
 
+import java.util.List;
+
 import javax.portlet.PortletRequest;
 
 import org.jasig.portlet.calendar.CalendarSet;
+import org.jasig.portlet.calendar.PredefinedCalendarConfiguration;
 
 public interface ICalendarSetDao {
     
-    public CalendarSet<?> getCalendarSet(PortletRequest request);
+    CalendarSet<?> getCalendarSet(PortletRequest request);
+    
+    List<PredefinedCalendarConfiguration> getAvailablePredefinedCalendarConfigurations(PortletRequest request);
 
 }

--- a/src/main/java/org/jasig/portlet/calendar/dao/PortletPreferencesCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/PortletPreferencesCalendarSetDao.java
@@ -20,6 +20,7 @@
 package org.jasig.portlet.calendar.dao;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Resource;
@@ -35,6 +36,8 @@ import org.jasig.portlet.calendar.CalendarSet;
 import org.jasig.portlet.calendar.PredefinedCalendarConfiguration;
 import org.springframework.beans.factory.annotation.Required;
 
+import edu.emory.mathcs.backport.java.util.Collections;
+
 /**
  * PortletPreferencesCalendarSetDao provides a portlet preference-based 
  * implementation of the ICalendarSetDao interface.  This implementation is
@@ -42,7 +45,7 @@ import org.springframework.beans.factory.annotation.Required;
  * configuration or interact with any of the roles features.
  * 
  * @author Jen Bourey, jbourey@unicon.net
- * @version $Revision$
+ * @deprecated Use {@link WhitelistFilteringCalendarSetDao} instead.
  */
 public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
     
@@ -78,6 +81,13 @@ public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
         
     }
     
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<PredefinedCalendarConfiguration> getAvailablePredefinedCalendarConfigurations(PortletRequest request) {
+        // Send an empty list because the set of calendars is fix for this ICalendarSetDao...
+        return Collections.emptyList();
+    }
+
     /*
      * Implementation
      */

--- a/src/main/java/org/jasig/portlet/calendar/dao/WhitelistFilteringCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/WhitelistFilteringCalendarSetDao.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.calendar.dao;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+
+import org.jasig.portlet.calendar.CalendarConfiguration;
+import org.jasig.portlet.calendar.CalendarSet;
+import org.jasig.portlet.calendar.PredefinedCalendarConfiguration;
+import org.jasig.portlet.calendar.PredefinedCalendarDefinition;
+
+import edu.emory.mathcs.backport.java.util.Arrays;
+
+/**
+ * Decorates another instance of {@link ICalendarSetDao} and filters the results 
+ * it provides by the specified whilelist, unless the list is empty.  In that 
+ * case all results will be displayed.
+ * 
+ * @author awills
+ */
+public class WhitelistFilteringCalendarSetDao implements ICalendarSetDao {
+    
+    private ICalendarSetDao enclosedCalendarSetDao;
+    
+    public void setEnclosedCalendarSetDao(ICalendarSetDao enclosedCalendarSetDao) {
+        this.enclosedCalendarSetDao = enclosedCalendarSetDao;
+    }
+
+    /**
+     * If this preference is non-empty, only calendar-definitions whose fnames 
+     * appear in the whitelist will be shown.
+     */
+    private static final String CALENDAR_WHITELIST_PREFERENCE = "calendarWhitelist";
+
+    @Override
+    public CalendarSet<?> getCalendarSet(PortletRequest req) {
+        
+        final CalendarSet<? extends CalendarConfiguration> unmodifiedSet = 
+                enclosedCalendarSetDao.getCalendarSet(req);
+
+        final List<String> whitelist = getWhitelist(req);
+        if (whitelist.size() == 0) {
+            // No filtering to do...
+            return unmodifiedSet;
+        }
+        
+        /*
+         * A whitelist of allowed calender-definition fnames has been defined, 
+         * so we must filter out calendar-definitions that are not on the list
+         */
+        
+        final Set<CalendarConfiguration> configurations = new HashSet<CalendarConfiguration>();
+
+        final Set<? extends CalendarConfiguration> rawSet = unmodifiedSet.getConfigurations(); 
+        for (CalendarConfiguration config : rawSet) {
+            if (config.getCalendarDefinition() instanceof PredefinedCalendarDefinition) {
+                final PredefinedCalendarDefinition pdef = (PredefinedCalendarDefinition) 
+                        config.getCalendarDefinition();
+                // Make sure it appears on the whitelist
+                if (whitelist.contains(pdef.getFname())) {
+                    configurations.add(config);
+                }
+            } else {
+                // User-defined calendar-definitions always pass through;  if you 
+                // intend to prevent them, set disablePreferences to 'true'
+                configurations.add(config);
+            }
+        }
+        
+        final CalendarSet<CalendarConfiguration> rslt = new CalendarSet<CalendarConfiguration>();
+        rslt.setConfigurations(configurations);
+        return rslt;
+    
+    }
+
+    @Override
+    public List<PredefinedCalendarConfiguration> getAvailablePredefinedCalendarConfigurations(
+            PortletRequest req) {
+
+        final List<PredefinedCalendarConfiguration> unmodifiedList = 
+                enclosedCalendarSetDao.getAvailablePredefinedCalendarConfigurations(req);
+
+        final List<String> whitelist = getWhitelist(req);
+        if (whitelist.size() == 0) {
+            // No filtering to do...
+            return unmodifiedList;
+        }
+
+        /*
+         * A whitelist of allowed calender-definition fnames has been defined, 
+         * so we must filter out calendar-definitions that are not on the list
+         */
+
+        final List<PredefinedCalendarConfiguration> rslt = new ArrayList<PredefinedCalendarConfiguration>();
+
+        for (PredefinedCalendarConfiguration config :  unmodifiedList) {
+            final PredefinedCalendarDefinition pdef = (PredefinedCalendarDefinition) 
+                    config.getCalendarDefinition();
+            if (whitelist.contains(pdef.getFname())) {
+                rslt.add(config);
+            }
+        }
+
+        return rslt;
+        
+    }
+
+    /*
+     * Implementation
+     */
+    
+    private List<String> getWhitelist(PortletRequest req) {
+        final PortletPreferences prefs = req.getPreferences();
+        @SuppressWarnings("unchecked")
+        final List<String> rslt = Arrays.asList(prefs.getValues(CALENDAR_WHITELIST_PREFERENCE, new String[0]));
+        return rslt;
+    }
+
+}

--- a/src/main/java/org/jasig/portlet/calendar/mvc/controller/AjaxCalendarController.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/controller/AjaxCalendarController.java
@@ -56,7 +56,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.portlet.ModelAndView;
 import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 

--- a/src/main/java/org/jasig/portlet/calendar/mvc/controller/EditCalendarSubscriptionsController.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/controller/EditCalendarSubscriptionsController.java
@@ -40,6 +40,7 @@ import org.jasig.portlet.calendar.PredefinedCalendarConfiguration;
 import org.jasig.portlet.calendar.PredefinedCalendarDefinition;
 import org.jasig.portlet.calendar.UserDefinedCalendarConfiguration;
 import org.jasig.portlet.calendar.dao.CalendarStore;
+import org.jasig.portlet.calendar.dao.ICalendarSetDao;
 import org.jasig.portlet.calendar.mvc.CalendarPreferencesCommand;
 import org.jasig.portlet.calendar.mvc.IViewSelector;
 import org.jasig.portlet.calendar.service.SessionSetupInitializationService;
@@ -103,7 +104,7 @@ public class EditCalendarSubscriptionsController {
 		model.put("mycalendars", mycalendars);
 
 		// add the predefined calendars to the model
-		List<PredefinedCalendarConfiguration> calendars = calendarStore.getPredefinedCalendarConfigurations(subscribeId, false);
+		List<PredefinedCalendarConfiguration> calendars = calendarSetDao.getAvailablePredefinedCalendarConfigurations(request);
 		model.put("calendars", calendars);
 		
 		// get the user's role listings
@@ -271,6 +272,13 @@ public class EditCalendarSubscriptionsController {
 	public void setCalendarStore(CalendarStore calendarStore) {
 		this.calendarStore = calendarStore;
 	}
+
+    private ICalendarSetDao calendarSetDao;
+    
+    @Autowired(required = true)
+    public void setCalendarSetDao(ICalendarSetDao calendarSetDao) {
+        this.calendarSetDao = calendarSetDao;
+    }
 
     private IViewSelector viewSelector;
 

--- a/src/main/webapp/WEB-INF/context/portlet/calendar.xml
+++ b/src/main/webapp/WEB-INF/context/portlet/calendar.xml
@@ -46,7 +46,11 @@
         </property>
     </bean>
     
-    <bean id="calendarSetDao" class="org.jasig.portlet.calendar.dao.HibernateCalendarSetDao"/>
+    <bean id="calendarSetDao" class="org.jasig.portlet.calendar.dao.WhitelistFilteringCalendarSetDao">
+        <property name="enclosedCalendarSetDao">
+            <bean class="org.jasig.portlet.calendar.dao.HibernateCalendarSetDao"/>
+        </property>
+    </bean>
     
     <bean id="viewSelector" class="org.jasig.portlet.calendar.mvc.ThemeNameViewSelectorImpl"/>
     


### PR DESCRIPTION
...thin the CalendarSet for portlet publication

This approach is much better than the previous PortletPreferencesCalendarSetDao, which is deprecated in this change.
- It does not require a change to the portlet context or separate portlet definition (with a custom context)
- It honors the audience information in the calendar-definition
- It is more in keeping with the rest of the data model and with the roadmap involving CalendarSets
