### PR TITLE
CAPP-133

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
                 <version>1.3</version>
             </dependency>
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.6</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>3.2</version>
@@ -585,6 +590,12 @@
 
 
         <!-- ===== Runtime Dependencies ================================== -->
+        <!-- commons-codec 1.6 is required for the CoursesPortlet integration -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>net.sourceforge.nekohtml</groupId>
             <artifactId>nekohtml</artifactId>


### PR DESCRIPTION
Add commons-codec 1.6 as a runtime dependency as it is used in the CoursesPortlet and is accessed within the Courses iCal adapter.
