### PR TITLE
Update calendarContext.xml

### DIFF
--- a/src/main/webapp/WEB-INF/context/calendarContext.xml
+++ b/src/main/webapp/WEB-INF/context/calendarContext.xml
@@ -39,7 +39,7 @@
         <value>America/Phoenix</value>
         <value>America/Los_Angeles</value>
         <value>America/Anchorage</value>
-        <value>America/Hawaii</value>        
+        <value>US/Hawaii</value>        
     </util:list>
     
     


### PR DESCRIPTION
American/Hawaii is not a valid timezone.  It should be US/Hawaii.  See the following:
http://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/timezone.html or http://en.wikipedia.org/wiki/Zone.tab
