### PR TITLE
Exchange Calendar Adapter using impersonation activated by default. A

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -956,6 +956,40 @@
         </plugins>
     </build>
     <profiles>
+    <profile>
+			<id>default</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<argLine>-XX:PermSize=256m -XX:MaxPermSize=256m</argLine>
+							<excludes>
+								<exclude>**/ExchangeCalendarAdapterIntegrationTest.java</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>system_test</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<argLine>-XX:PermSize=256m -XX:MaxPermSize=256m</argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
         <profile>
             <id>site</id>
             <distributionManagement>

--- a/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWebServiceCallBack.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWebServiceCallBack.java
@@ -1,0 +1,58 @@
+package org.jasig.portlet.calendar.adapter.exchange;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.xml.namespace.QName;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.client.core.WebServiceMessageCallback;
+import org.springframework.ws.soap.SoapHeaderElement;
+import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.soap.client.core.SoapActionCallback;
+import org.springframework.xml.transform.StringSource;
+
+@NotThreadSafe
+public class ExchangeWebServiceCallBack implements WebServiceMessageCallback {
+	private String localDomainName;
+	private final Log log = LogFactory.getLog(getClass());
+	private final String username;
+	private final WebServiceMessageCallback actionCallback;
+	private String requestServerVersion;
+	private final String impersonationFirstPart= "<t:ExchangeImpersonation"
+    		+ " xmlns:t=\"http://schemas.microsoft.com/exchange/services/2006/types\">"
+    		+ "<t:ConnectingSID><t:PrincipalName>";
+	private final String impersonationSecondPart =  "</t:PrincipalName></t:ConnectingSID></t:ExchangeImpersonation>";
+	public ExchangeWebServiceCallBack(String username,String actionCallbackType, String requestServerVersion, String localDomainName){
+		this.username=username;
+		this.actionCallback= new SoapActionCallback(
+				actionCallbackType);
+		this.requestServerVersion=requestServerVersion;
+		this.localDomainName=localDomainName;
+	}
+	@Override
+    public void doWithMessage(WebServiceMessage message) throws IOException, TransformerException {
+        actionCallback.doWithMessage(message);
+        SoapMessage soap = (SoapMessage) message;
+        QName rsv = new QName(
+                "http://schemas.microsoft.com/exchange/services/2006/types", 
+                "RequestServerVersion", 
+                "ns3"); 
+        SoapHeaderElement version = soap.getEnvelope().getHeader()
+                                        .addHeaderElement(rsv);
+        version.addAttribute(new QName("Version"), requestServerVersion);
+        StringSource headerSource = new StringSource(impersonationFirstPart+username+"@"+localDomainName+impersonationSecondPart);
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.transform(headerSource, soap.getEnvelope().getHeader().getResult());
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();  
+        message.writeTo(bout); 
+        String msg = bout.toString("UTF-8");  
+        log.debug("Sending a SOAP message: " + msg);
+    }
+}

--- a/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWsCredentialsProvider.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWsCredentialsProvider.java
@@ -19,26 +19,21 @@
 
 package org.jasig.portlet.calendar.adapter.exchange;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.CredentialsProvider;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
 
 public class ExchangeWsCredentialsProvider implements CredentialsProvider {
-
+	protected final Log log = LogFactory.getLog(getClass());
     protected static final String EXCHANGE_CREDENTIALS_ATTRIBUTE = "exchangeCredentials";
-
     @Override
     public void clear() { /* no-op */}
 
     @Override
     public Credentials getCredentials(AuthScope authscope) {
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        final Credentials credentials = (Credentials) requestAttributes.getAttribute(
-                ExchangeWsCredentialsProvider.EXCHANGE_CREDENTIALS_ATTRIBUTE, 
-                RequestAttributes.SCOPE_SESSION);            
-        return credentials;
+        return ExchangeCredentialsInitializationService.credentials;
     }
 
     @Override

--- a/src/main/java/org/jasig/portlet/calendar/mvc/ThemeNameViewSelectorImpl.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/ThemeNameViewSelectorImpl.java
@@ -22,6 +22,8 @@ package org.jasig.portlet.calendar.mvc;
 import javax.portlet.PortletRequest;
 import javax.portlet.WindowState;
 
+import org.springframework.stereotype.Component;
+
 /**
  * ThemeNameViewSelectorImpl determines appropriate views by examining a "themeName"
  * portlet request property and comparing it to known mobile theme names.  This
@@ -32,6 +34,7 @@ import javax.portlet.WindowState;
  * @author Jen Bourey, jennifer.bourey@gmail.com
  * @version $Revision$
  */
+@Component
 public class ThemeNameViewSelectorImpl implements IViewSelector {
     
     private final String CALENDAR_WIDE_VIEW = "calendarWideView";

--- a/src/main/java/org/jasig/portlet/calendar/mvc/UICalendarEventsBuilder.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/UICalendarEventsBuilder.java
@@ -1,0 +1,90 @@
+package org.jasig.portlet.calendar.mvc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.portlet.PortletSession;
+import javax.portlet.ResourceRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.joda.time.DateMidnight;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
+import org.springframework.stereotype.Component;
+@Component
+public class UICalendarEventsBuilder {
+	protected final Log log = LogFactory.getLog(this.getClass());
+	
+	public Map <String,Object> buildUIEvents(Set<CalendarDisplayEvent> calendarEvents, ResourceRequest request, List<String> errors){
+	    final Map<String, Object> model = new HashMap<String, Object>();
+	    final PortletSession session = request.getPortletSession();
+        final String timezone = (String) session.getAttribute("timezone");
+        final DateTimeZone tz = DateTimeZone.forID(timezone);
+		int index = 0;
+		final Set<JsonCalendarEventWrapper> events = new TreeSet<JsonCalendarEventWrapper>();
+        for(CalendarDisplayEvent e : calendarEvents) {
+            events.add(new JsonCalendarEventWrapper(e,index++));
+        }
+		/*
+		 * Transform the event set into a map keyed by day.  This code is 
+		 * designed to separate events by day according to the user's configured
+		 * time zone.  This ensures that we keep complicated time-zone handling
+		 * logic out of the JavaScript.
+		 * 
+		 * Events are keyed by a string uniquely representing the date that is 
+		 * still orderable.  So that we can display a more user-friendly date
+		 * name, we also create a map representing date display names for each
+		 * date keyed in this response.
+		 */
+		// define a DateFormat object that uniquely identifies dates in a way 
+		// that can easily be ordered 
+        DateTimeFormatter orderableDf = new DateTimeFormatterBuilder()
+                .appendYear(4, 4).appendLiteral("-").appendMonthOfYear(2)
+                .appendLiteral("-").appendDayOfMonth(2).toFormatter()
+                .withZone(tz);
+        DateTimeFormatter displayDf = new DateTimeFormatterBuilder()
+                .appendDayOfWeekText().appendLiteral(" ")
+                .appendMonthOfYearText().appendLiteral(" ").appendDayOfMonth(1)
+                .toFormatter().withZone(tz);
+        DateMidnight now = new DateMidnight(tz);
+		String today = orderableDf.print(now);
+		String tomorrow = orderableDf.print(now.plusDays(1));
+		Map<String, String> dateDisplayNames = new HashMap<String, String>();
+		Map<String, List<JsonCalendarEventWrapper>> eventsByDay = new LinkedHashMap<String, List<JsonCalendarEventWrapper>>();
+		for (JsonCalendarEventWrapper event : events) {
+			String day = orderableDf.print(event.getEvent().getDayStart());
+	    	if (!eventsByDay.containsKey(day)) {
+	    		eventsByDay.put(day, new ArrayList<JsonCalendarEventWrapper>());
+	    		
+	    		// Add an appropriate day name for this date to the date names
+	    		// map.  If the day appears to be today or tomorrow display a 
+	    		// special string value.  Otherwise, use the user-facing date
+	    		// format object
+	    		if (today.equals(day)) {
+		    		dateDisplayNames.put(day, "Today");
+	    		} else if (tomorrow.equals(day)) {
+		    		dateDisplayNames.put(day, "Tomorrow");
+	    		} else {
+		    		dateDisplayNames.put(day, displayDf.print(event.getEvent().getDayStart()));
+	    		}
+	    	}
+	    	eventsByDay.get(day).add(event);
+		}
+		if (log.isTraceEnabled()) {
+	        log.trace("Prepared the following eventsByDay collection for user '" 
+	                            + request.getRemoteUser() + "':" + eventsByDay);
+		}
+		model.put("dateMap", eventsByDay);
+		model.put("dateNames", dateDisplayNames);
+		model.put("viewName", "jsonView");
+		model.put("errors", errors);
+		return model;
+	}
+}

--- a/src/main/java/org/jasig/portlet/calendar/mvc/controller/AjaxCalendarController.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/controller/AjaxCalendarController.java
@@ -21,17 +21,13 @@ package org.jasig.portlet.calendar.mvc.controller;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 import javax.annotation.Resource;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
-import javax.portlet.PortletSession;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
 import javax.servlet.http.HttpServletResponse;
@@ -49,14 +45,10 @@ import org.jasig.portlet.calendar.dao.CalendarStore;
 import org.jasig.portlet.calendar.dao.ICalendarSetDao;
 import org.jasig.portlet.calendar.mvc.CalendarDisplayEvent;
 import org.jasig.portlet.calendar.mvc.CalendarHelper;
-import org.jasig.portlet.calendar.mvc.JsonCalendarEventWrapper;
+import org.jasig.portlet.calendar.mvc.UICalendarEventsBuilder;
 import org.jasig.portlet.calendar.util.DateUtil;
-import org.joda.time.DateMidnight;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.DateTimeFormatterBuilder;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,8 +65,23 @@ import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 @Controller
 @RequestMapping("VIEW")
 public class AjaxCalendarController implements ApplicationContextAware {
+	@Autowired
+	private UICalendarEventsBuilder uiCalendarEventBuiler;
 
+    @Autowired(required = true)
+    private CalendarHelper helper;
+
+    @Autowired(required = true)
+    private CalendarEventsDao calendarEventsDao;
+
+    @Autowired(required = true)
+	private ICalendarSetDao calendarSetDao;
+
+
+    private CalendarStore calendarStore;
+    private ApplicationContext applicationContext;
 	protected final Log log = LogFactory.getLog(this.getClass());
+
 
     @ActionMapping(params = "action=showDatePicker")
     public void toggleShowDatePicker(@RequestParam(value = "show") String show,
@@ -92,138 +99,37 @@ public class AjaxCalendarController implements ApplicationContextAware {
 	@ResourceMapping
 	public ModelAndView getEventList(ResourceRequest request,
 			ResourceResponse response) throws Exception {
-	    
-        // Pull parameters out of the resourceId
         final String resourceId = request.getResourceID();
-        final String[] resourceIdTokens = resourceId.split("-");        
+        final String[] resourceIdTokens = resourceId.split("_");        
         final String startDate = resourceIdTokens[0];
         final int days = Integer.parseInt(resourceIdTokens[1]);
-        final boolean refresh = resourceIdTokens.length > 2
-                ? Boolean.valueOf(resourceIdTokens[2])
-                : false;
-
+        final String requestEtag  = resourceIdTokens.length > 2
+                ?resourceIdTokens[2]: "";
         final long startTime = System.currentTimeMillis();
         final List<String> errors = new ArrayList<String>();
-		final Map<String, Object> model = new HashMap<String, Object>();
-        final PortletSession session = request.getPortletSession();
-        // get the user's configured time zone
-        final String timezone = (String) session.getAttribute("timezone");
-        final DateTimeZone tz = DateTimeZone.forID(timezone);
-
-        // get the period for this request
         final Interval interval = DateUtil.getInterval(startDate, days,request);
-
         final Set<CalendarDisplayEvent> calendarEvents = helper.getEventList(errors,interval,request);
-
-		int index = 0;
-		final Set<JsonCalendarEventWrapper> events = new TreeSet<JsonCalendarEventWrapper>();
-        for(CalendarDisplayEvent e : calendarEvents) {
-            events.add(new JsonCalendarEventWrapper(e,index++));
-        }
-
-		/*
-		 * Transform the event set into a map keyed by day.  This code is 
-		 * designed to separate events by day according to the user's configured
-		 * time zone.  This ensures that we keep complicated time-zone handling
-		 * logic out of the JavaScript.
-		 * 
-		 * Events are keyed by a string uniquely representing the date that is 
-		 * still orderable.  So that we can display a more user-friendly date
-		 * name, we also create a map representing date display names for each
-		 * date keyed in this response.
-		 */
-
-		// define a DateFormat object that uniquely identifies dates in a way 
-		// that can easily be ordered 
-        DateTimeFormatter orderableDf = new DateTimeFormatterBuilder()
-                .appendYear(4, 4).appendLiteral("-").appendMonthOfYear(2)
-                .appendLiteral("-").appendDayOfMonth(2).toFormatter()
-                .withZone(tz);
-
-        // define a DateFormat object that can produce user-facing display 
-        // names for dates
-        DateTimeFormatter displayDf = new DateTimeFormatterBuilder()
-                .appendDayOfWeekText().appendLiteral(" ")
-                .appendMonthOfYearText().appendLiteral(" ").appendDayOfMonth(1)
-                .toFormatter().withZone(tz);
-
-		// define "today" and "tomorrow" so we can display these specially in the
-		// user interface
-        DateMidnight now = new DateMidnight(tz);
-		String today = orderableDf.print(now);
-		String tomorrow = orderableDf.print(now.plusDays(1));
-
-		Map<String, String> dateDisplayNames = new HashMap<String, String>();
-		Map<String, List<JsonCalendarEventWrapper>> eventsByDay = new LinkedHashMap<String, List<JsonCalendarEventWrapper>>();
-		for (JsonCalendarEventWrapper event : events) {
-			String day = orderableDf.print(event.getEvent().getDayStart());
-			
-			// if we haven't seen this day before, add entries to the event
-			// and date name maps
-	    	if (!eventsByDay.containsKey(day)) {
-	    		
-	    		// add a list for this day to the eventsByDay map
-	    		eventsByDay.put(day, new ArrayList<JsonCalendarEventWrapper>());
-	    		
-	    		// Add an appropriate day name for this date to the date names
-	    		// map.  If the day appears to be today or tomorrow display a 
-	    		// special string value.  Otherwise, use the user-facing date
-	    		// format object
-	    		if (today.equals(day)) {
-		    		dateDisplayNames.put(day, "Today");
-	    		} else if (tomorrow.equals(day)) {
-		    		dateDisplayNames.put(day, "Tomorrow");
-	    		} else {
-		    		dateDisplayNames.put(day, displayDf.print(event.getEvent().getDayStart()));
-	    		}
-	    	}
-	    	
-	    	// add the event to the by-day map
-	    	eventsByDay.get(day).add(event);
-		}
-		
-		if (log.isTraceEnabled()) {
-	        log.trace("Prepared the following eventsByDay collection for user '" 
-	                            + request.getRemoteUser() + "':" + eventsByDay);
-		}
-
-		model.put("dateMap", eventsByDay);
-		model.put("dateNames", dateDisplayNames);
-		model.put("viewName", "jsonView");
-		model.put("errors", errors);
-
+        Map <String,Object> model = uiCalendarEventBuiler.buildUIEvents(calendarEvents,request,errors);
 		String etag = String.valueOf(model.hashCode());
-		String requestEtag = request.getETag();
-
-		// if the request ETag matches the hash for this response, send back
-		// an empty response indicating that cached content should be used
-        if (!refresh && request.getETag() != null && etag.equals(requestEtag)) {
+		response.getCacheControl().setETag(etag);
+		response.getCacheControl().setUseCachedContent(false);
+		response.getCacheControl().setExpirationTime(0);
+        if (!requestEtag.isEmpty() && etag.equals(requestEtag)) {
             if (log.isTraceEnabled()) {
                 log.trace("Sending an empty response (due to matched ETag and " 
                             + "refresh=false) for user '" 
                             + request.getRemoteUser() + "'");
             }
-            response.getCacheControl().setExpirationTime(1);
-            response.getCacheControl().setETag(etag);
-            response.getCacheControl().setUseCachedContent(true);
             response.setProperty(ResourceResponse.HTTP_STATUS_CODE, Integer.toString(HttpServletResponse.SC_NOT_MODIFIED));
             // returning null appears to cause the response to be committed
             // before returning to the portal, so just use an empty view
             return new ModelAndView("empty", Collections.<String,String>emptyMap());
         }
-        
         if (log.isTraceEnabled()) {
-            log.trace("Sending a full response for user '" + request.getRemoteUser() 
-                                                    + "' and refresh=" + refresh);
+            log.trace("Sending a full response for user '" + request.getRemoteUser());
         }
-
-        // create new content with new validation tag
-        response.getCacheControl().setETag(etag);
-        response.getCacheControl().setExpirationTime(1);
-        
         long overallTime = System.currentTimeMillis() - startTime;
         log.debug("AjaxCalendarController took " + overallTime + " ms to produce JSON model");
-
         return new ModelAndView("json", model);
 	}
 	
@@ -265,25 +171,12 @@ public class AjaxCalendarController implements ApplicationContextAware {
         throw exception;
     }
 
-    @Autowired(required = true)
-    private CalendarHelper helper;
-
-    @Autowired(required = true)
-    private CalendarEventsDao calendarEventsDao;
-
-    @Autowired(required = true)
-	private ICalendarSetDao calendarSetDao;
-
-
-    private CalendarStore calendarStore;
-
     @Required
     @Resource(name="calendarStore")
     public void setCalendarStore(CalendarStore calendarStore) {
         this.calendarStore = calendarStore;
     }
 
-    private ApplicationContext applicationContext;
 	public void setApplicationContext(ApplicationContext applicationContext)
 			throws BeansException {
 		this.applicationContext = applicationContext;

--- a/src/main/java/org/jasig/portlet/calendar/mvc/controller/CalendarController.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/controller/CalendarController.java
@@ -123,7 +123,7 @@ public class CalendarController implements ApplicationContextAware {
         // See if we're configured to show or hide the jQueryUI DatePicker.
         // By default, we assume we are to show the DatePicker because that's
         // the classic behavior.
-        String showDatePicker = prefs.getValue( "showDatePicker", "true" );
+        String showDatePicker = prefs.getValue( "showDatePicker", "false" );
         model.put( "showDatePicker", showDatePicker );
 
 		/**

--- a/src/main/resources/com/microsoft/exchange/Services.wsdl
+++ b/src/main/resources/com/microsoft/exchange/Services.wsdl
@@ -1014,7 +1014,7 @@
   </wsdl:binding>
   <wsdl:service name="ExchangeWebService">
       <wsdl:port name="ExchangeWebPort" binding="tns:ExchangeServiceBinding">
-             <soap:address location="https://mail.school.edu/EWS/exchange.asmx"></soap:address>
+             <soap:address location="https://outlook.office365.com/EWS/Exchange.asmx"></soap:address>
       </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -21,10 +21,11 @@ cas.server.base.url=http://localhost:8080/cas
 portal.server.base.url=http://localhost:8080
 portlet.context=CalendarPortlet
 portal.proxy.receptor.path=uPortal/CasProxyServlet
-userinfo.userid.key=user.login.id
+userinfo.userid.key=uid
 userinfo.password.key=password
 
-# The following 2 properties are used with the Exchange WS integration
+# The following 3 properties are used with the Exchange WS integration
+localdomainname=ed.ac.uk
 #
 
 ntlm.domain=changeMe (if applicable)
@@ -36,4 +37,4 @@ ntlm.domain=changeMe (if applicable)
 #   - Exchange2010_SP1
 #   - Exchange2010_SP2
 #
-exchangeWs.requestServerVersion=Exchange2010_SP2
+exchangeWs.requestServerVersion=Exchange2010_SP1

--- a/src/main/resources/portlet-logging.properties
+++ b/src/main/resources/portlet-logging.properties
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-log4j.rootCategory=WARN, R
-log4j.category.org.jasig=INFO, R
+log4j.rootCategory=DEBUG, R
+log4j.category.org.jasig=DEBUG, R
 log4j.additivity.org.jasig=false
 
 #Silence an erroneous WARN level log message from Hibernate

--- a/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -138,7 +138,7 @@
     <!-- 
      | View resolvers, look for a named view bean before going to JSP resolution
      +-->
-    <bean class="org.springframework.web.servlet.view.XmlViewResolver"
+    <bean id="xmlviewresolver" class="org.springframework.web.servlet.view.XmlViewResolver"
             p:order="0" p:location="/WEB-INF/context/views.xml"/>
 
 	<!-- JSP view resolver -->

--- a/src/main/webapp/WEB-INF/context/calendarContext.xml
+++ b/src/main/webapp/WEB-INF/context/calendarContext.xml
@@ -31,16 +31,44 @@
     http://www.springmodules.org/schema/ehcache http://www.springmodules.org/schema/cache/springmodules-ehcache.xsd">
 
     <!-- User timezone options -->
-    <util:list id="timeZones">
-        <!--<value>America/Halifax</value>-->
-        <value>America/New_York</value>
-        <value>America/Chicago</value>
-        <value>America/Denver</value>
-        <value>America/Phoenix</value>
-        <value>America/Los_Angeles</value>
-        <value>America/Anchorage</value>
-        <value>US/Hawaii</value>        
-    </util:list>
+	<util:list id="timeZones">
+		<value>Europe/London</value>
+		<value>Etc/GMT+0</value>
+		<value>Etc/GMT+1</value>
+		<value>Etc/GMT+10</value>
+		<value>Etc/GMT+11</value>
+		<value>Etc/GMT+12</value>
+		<value>Etc/GMT+2</value>
+		<value>Etc/GMT+3</value>
+		<value>Etc/GMT+4</value>
+		<value>Etc/GMT+5</value>
+		<value>Etc/GMT+6</value>
+		<value>Etc/GMT+7</value>
+		<value>Etc/GMT+8</value>
+		<value>Etc/GMT+9</value>
+		<value>Etc/GMT-0</value>
+		<value>Etc/GMT-1</value>
+		<value>Etc/GMT-10</value>
+		<value>Etc/GMT-11</value>
+		<value>Etc/GMT-12</value>
+		<value>Etc/GMT-13</value>
+		<value>Etc/GMT-14</value>
+		<value>Etc/GMT-2</value>
+		<value>Etc/GMT-3</value>
+		<value>Etc/GMT-4</value>
+		<value>Etc/GMT-5</value>
+		<value>Etc/GMT-6</value>
+		<value>Etc/GMT-7</value>
+		<value>Etc/GMT-8</value>
+		<value>Etc/GMT-9</value>
+		<value>America/New_York</value>
+		<value>America/Chicago</value>
+		<value>America/Denver</value>
+		<value>America/Phoenix</value>
+		<value>America/Los_Angeles</value>
+		<value>America/Anchorage</value>
+		<value>America/Hawaii</value>
+	</util:list>
     
     
     <!--
@@ -120,7 +148,7 @@
      | src/main/resources/com/microsoft/exchange/Service.wsdl and uncomment the
      | reference to the ExchangeInitializationService bean in calendar.xml. 
      +-->
-    <!--bean id="marshaller" class="org.springframework.oxm.jaxb.Jaxb2Marshaller">
+    <bean id="marshaller" class="org.springframework.oxm.jaxb.Jaxb2Marshaller">
         <property name="contextPaths">
             <list>
                 <value>com.microsoft.exchange.messages</value>
@@ -137,17 +165,6 @@
             <bean class="org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager"/>
         </constructor-arg>
     </bean>
-    <!- The connection is attempted 5 times prior to stopping
-        so the actual time before failure will be 5 times p:connectionTimeout 
-        Suggested way of testing Connection Timeout is by hitting a
-        domain with a port that is firewalled:
-        ie. http://www.google.com:81
-        
-        Suggested way of testing Socket Timeout(p:readTimeout) is by using a tool locally to connect
-        but not respond.  Example tool: bane
-        http://blog.danielwellman.com/2010/09/introducing-bane-a-test-harness-for-server-connections.html
-        usage: $bane 10010 NeverRespond
-        ie http://localhost:10010 ->
     <bean id="webServiceMessageSender" class="org.springframework.ws.transport.http.HttpComponentsMessageSender"
         p:httpClient-ref="httpClient" p:connectionTimeout="60000" p:readTimeout="60000"
         p:maxTotalConnections="200">
@@ -163,12 +180,14 @@
         p:titleKey="exchange.ws.integration" 
         p:descriptionKey="exchange.ws.integration"
         p:emailAttribute="mail"
-        p:requestServerVersion="${exchangeWs.requestServerVersion}">
-        <property name="cacheKeyGenerator">
-            <bean class="org.jasig.portlet.calendar.caching.DefaultCacheKeyGeneratorImpl"
-                  p:includePeriod="true"/>
-        </property>
-    </bean-->
+        p:requestServerVersion="${exchangeWs.requestServerVersion}"
+        p:localDomainName="${localdomainname}">
+        <property name="cacheKeyGenerator"> 
+            <bean 
+			class="org.jasig.portlet.calendar.caching.DefaultCacheKeyGeneratorImpl" 
+                   p:includePeriod="true"/> 
+         </property> 
+    </bean>
 
     <!-- 
      | CalDAV adapter for calendars available via the CalDAV protocol.

--- a/src/main/webapp/WEB-INF/context/portlet/calendar.xml
+++ b/src/main/webapp/WEB-INF/context/portlet/calendar.xml
@@ -31,7 +31,7 @@
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd  
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
-    <context:component-scan base-package="org.jasig.portlet.calendar.mvc.controller"/>
+    <context:component-scan base-package="org.jasig.portlet.calendar.mvc"/>
     <context:annotation-config/>
     
     <!-- Properties configuration -->
@@ -51,10 +51,6 @@
             <bean class="org.jasig.portlet.calendar.dao.HibernateCalendarSetDao"/>
         </property>
     </bean>
-
-    <bean id="calendarHelper" class="org.jasig.portlet.calendar.mvc.CalendarHelper"/>
-
-    <bean id="viewSelector" class="org.jasig.portlet.calendar.mvc.ThemeNameViewSelectorImpl"/>
     
     <util:list id="initializationServices">
         
@@ -67,9 +63,7 @@
         <!--
             Uncomment the following section for MS Exchange calendars
         -->
-        <!--bean class="org.jasig.portlet.calendar.adapter.exchange.ExchangeCredentialsInitializationService"
-            p:usernameAttribute="${userinfo.userid.key}" p:passwordAttribute="${userinfo.password.key}"
-            p:ntlmDomain="${ntlm.domain}"/-->
+        <bean class="org.jasig.portlet.calendar.adapter.exchange.ExchangeCredentialsInitializationService"/>
         
         <!--
             Uncomment the following section if you are using CAS authenticated calendar adapters.

--- a/src/main/webapp/WEB-INF/jsp/calendarMobileView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarMobileView.jsp
@@ -180,7 +180,7 @@
             container: "#${n}container",
             listView: new ListView(),
             detailView: new DetailView(),
-            eventsUrl: '<portlet:resourceURL id="START-DAYS-REFRESH"/>', 
+            eventsUrl: '<portlet:resourceURL id="START_DAYS_ETAG"/>', 
             startDate: '<fmt:formatDate value="${model.startDate}" type="date" pattern="MM/dd/yyyy" timeZone="${ model.timezone }"/>', 
             days: "${ model.days }"
         });

--- a/src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp
@@ -223,7 +223,7 @@
             container: "#${n}container",
             listView: new ListView(),
             detailView: new DetailView(),
-            eventsUrl: '<portlet:resourceURL id="START-DAYS-REFRESH"/>', 
+            eventsUrl: '<portlet:resourceURL id="START_DAYS_ETAG"/>', 
             startDate: '<fmt:formatDate value="${model.startDate}" type="date" pattern="MM/dd/yyyy" timeZone="${ model.timezone }"/>', 
             days: "${ model.days }"
         });

--- a/src/main/webapp/WEB-INF/jsp/calendarWideView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarWideView.jsp
@@ -245,7 +245,7 @@
             container: "#${n}container",
             listView: new ListView(),
             detailView: new DetailView(),
-            eventsUrl: '<portlet:resourceURL id="START-DAYS-REFRESH"/>', 
+            eventsUrl: '<portlet:resourceURL id="START_DAYS_ETAG"/>', 
             startDate: '<fmt:formatDate value="${model.startDate}" type="date" pattern="MM/dd/yyyy" timeZone="${ model.timezone }"/>', 
             days: "${ model.days }"
         });

--- a/src/main/webapp/WEB-INF/portlet.xml
+++ b/src/main/webapp/WEB-INF/portlet.xml
@@ -44,16 +44,28 @@
         
         <portlet-preferences>
             
+             <preference>
+                <name>wsUser</name>
+                <value>masterusername@domain</value>
+             	<read-only>true</read-only>
+            </preference>
+            <preference>
+                <name>wsPassword</name>
+                <value>masteruserpassword</value>
+            	<read-only>true</read-only>
+            </preference>
+           
             <!-- Default display timezone -->
             <preference>
                 <name>timezone</name>
-                <value>America/Chicago</value>
+                <value>Europe/London</value>
+                <read-only>true</read-only>
             </preference>
 
             <!-- Default number of days worth of events to show -->
             <preference>
                 <name>days</name>
-                <value>7</value>
+                <value>1</value>
             </preference>
             
             <!-- Optionally disable users' access to the preferences screen -->
@@ -125,14 +137,17 @@
     </user-attribute-->
 
     <!-- Uncomment to use cached password authentication -->
-    <!--user-attribute>
+     <user-attribute>
         <name>password</name>
-    </user-attribute-->
+    </user-attribute>
 
     <!-- Uncomment to use Exchange -->
-    <!--user-attribute>
+    <user-attribute>
         <name>mail</name>
-    </user-attribute-->
+    </user-attribute>
+    <user-attribute>
+        <name>uid</name>
+    </user-attribute>
 
     <event-definition>
         <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchRequest</qname>

--- a/src/test/java/org/jasig/portlet/calendar/adapter/ExchangeCalendarAdapterIntegrationTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/adapter/ExchangeCalendarAdapterIntegrationTest.java
@@ -1,0 +1,29 @@
+package org.jasig.portlet.calendar.adapter;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jasig.portlet.calendar.caching.DefaultCacheKeyGeneratorImpl;
+import org.jasig.portlet.calendar.util.MockWebApplication;
+import org.jasig.portlet.calendar.util.MockWebApplicationContextLoader;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:/testApplicationContext.xml" },loader=MockWebApplicationContextLoader.class)
+@MockWebApplication(name="CalendarPortlet")
+public class ExchangeCalendarAdapterIntegrationTest {
+	
+	@Autowired
+	private ExchangeCalendarAdapter testee;
+	
+	@Test
+	public void testCacheGeneratorUserPeriodIsTrue(){
+		DefaultCacheKeyGeneratorImpl testeeCacheGenerator =  
+				(DefaultCacheKeyGeneratorImpl) ReflectionTestUtils.getField(testee, "cacheKeyGenerator");
+		assertTrue(testeeCacheGenerator.isIncludePeriod());
+	}
+}

--- a/src/test/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeCredentialsInitializationServiceTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeCredentialsInitializationServiceTest.java
@@ -21,62 +21,34 @@ package org.jasig.portlet.calendar.adapter.exchange;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.portlet.PortletRequest;
+import javax.portlet.ReadOnlyException;
 
-import org.apache.commons.httpclient.UsernamePasswordCredentials;
-import org.apache.http.auth.NTCredentials;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.mock.web.portlet.MockPortletPreferences;
 import org.springframework.mock.web.portlet.MockPortletRequest;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.portlet.context.PortletRequestAttributes;
 
 public class ExchangeCredentialsInitializationServiceTest {
 
     PortletRequest request;
     ExchangeCredentialsInitializationService service;
     
-    @Before
-    public void setUp() {
-        Map<String,String> userInfo = new HashMap<String,String>();
-        userInfo.put("username", "user");
-        userInfo.put("pass", "pass");
-
+     @Before
+    public void setUp() throws ReadOnlyException {
         request = new MockPortletRequest();
-        request.setAttribute(PortletRequest.USER_INFO, userInfo);
+        MockPortletPreferences mockPreferences = new MockPortletPreferences();
+        mockPreferences.setValue("wsUser", "blah@ed.ac.uk");
+        mockPreferences.setValue("wsPassword", "rand");
+        ((MockPortletRequest)request).setPreferences(mockPreferences);
         service = new ExchangeCredentialsInitializationService();
-        service.setPasswordAttribute("pass");
-        service.setUsernameAttribute("username");
     }
     
     @Test
     public void testInitialize() {
         service.initialize(request);
-        
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        final NTCredentials credentials = (NTCredentials) requestAttributes.getAttribute(ExchangeWsCredentialsProvider.EXCHANGE_CREDENTIALS_ATTRIBUTE, RequestAttributes.SCOPE_SESSION);
-        assertEquals("user", credentials.getUserName());
-        assertEquals("pass", credentials.getPassword());
-    }
-
-    
-    @Test
-    public void testWithExistingRequestInitialize() {
-        final RequestAttributes requestAttributes = new PortletRequestAttributes(request);
-        requestAttributes.setAttribute("testAttr", "testVal", RequestAttributes.SCOPE_SESSION);
-        RequestContextHolder.setRequestAttributes(requestAttributes);
-        
-        service.initialize(request);
-        
-        final RequestAttributes newRequestAttributes = RequestContextHolder.getRequestAttributes();
-        final NTCredentials credentials = (NTCredentials) newRequestAttributes.getAttribute(ExchangeWsCredentialsProvider.EXCHANGE_CREDENTIALS_ATTRIBUTE, RequestAttributes.SCOPE_SESSION);
-        assertEquals("user", credentials.getUserName());
-        assertEquals("pass", credentials.getPassword());
-        assertEquals("testVal", newRequestAttributes.getAttribute("testAttr", RequestAttributes.SCOPE_SESSION));
+        assertEquals("blah@ed.ac.uk", ExchangeCredentialsInitializationService.credentials.getUserName());
+        assertEquals("rand", ExchangeCredentialsInitializationService.credentials.getPassword());
     }
 
 }

--- a/src/test/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWebServiceCallBackTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWebServiceCallBackTest.java
@@ -1,0 +1,91 @@
+package org.jasig.portlet.calendar.adapter.exchange;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPException;
+import javax.xml.transform.TransformerException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.logging.Log;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.client.core.WebServiceMessageCallback;
+import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
+
+public class ExchangeWebServiceCallBackTest {
+
+	private String username = "username";
+	private String actionCallbackType = "actionCallbackType";
+	private String requestServerVersion = "requestServerVersion";
+	private SoapMessage request;
+	private ExchangeWebServiceCallBack testee;
+	private String localDomainName="ed.ac.uk";
+	@Mock
+	private Log mockLog;
+	@Mock
+	private WebServiceMessageCallback actionCallBackMock;
+	private ArgumentCaptor<String> logmessage;
+
+	@Before
+	public void setUp() throws IOException, SOAPException {
+		initMocks(this);
+		testee = new ExchangeWebServiceCallBack(username, actionCallbackType,
+				requestServerVersion, localDomainName);
+		File soapFile = new File(
+				"src/test/resources/TestGetAvailabilitySoapMessage.xml");
+		InputStream is = new ByteArrayInputStream(FileUtils.readFileToString(
+				soapFile).getBytes());
+		request = new SaajSoapMessageFactory(MessageFactory.newInstance())
+				.createWebServiceMessage(is);
+		ReflectionTestUtils.setField(testee, "log", mockLog);
+		logmessage = ArgumentCaptor.forClass(String.class);
+	}
+
+	@Test
+	public void testCorrectValuesWrittenToSoapMessage() throws IOException,
+			TransformerException {
+		testee.doWithMessage((WebServiceMessage) request);
+		verify(mockLog).debug(logmessage.capture());
+		assertTrue(logmessage.getValue().indexOf("requestServerVersion") != -1);
+		assertTrue(logmessage.getValue().indexOf("username") != -1);
+	}
+
+	@Test
+	// for some reason actioncallback is not written to soap body, goes into
+	// some kind of header which is visible in
+	// the logs if debug is on
+	public void testActionSetOnSoapMessage() throws IOException,
+			TransformerException {
+		ReflectionTestUtils.setField(testee, "actionCallback",
+				actionCallBackMock);
+		testee.doWithMessage((WebServiceMessage) request);
+		verify(actionCallBackMock).doWithMessage(eq(request));
+	}
+
+	@Test
+	public void testImpersonationAddedAsSoapHeader() throws IOException,
+			TransformerException {
+		testee.doWithMessage((WebServiceMessage) request);
+		verify(mockLog).debug(logmessage.capture());
+		assertTrue(logmessage.getValue().indexOf(
+				"<t:ExchangeImpersonation"
+			    		+ " xmlns:t=\"http://schemas.microsoft.com/exchange/services/2006/types\">"
+			    		+ "<t:ConnectingSID><t:PrincipalName>") != -1);
+		assertTrue(logmessage.getValue().indexOf(
+				username+"@"+localDomainName+ "</t:PrincipalName></t:ConnectingSID></t:ExchangeImpersonation>") != -1);
+	}
+}

--- a/src/test/java/org/jasig/portlet/calendar/mvc/controller/CalendarControllerTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/mvc/controller/CalendarControllerTest.java
@@ -1,0 +1,77 @@
+package org.jasig.portlet.calendar.mvc.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+
+import org.jasig.portlet.calendar.CalendarSet;
+import org.jasig.portlet.calendar.PredefinedCalendarConfiguration;
+import org.jasig.portlet.calendar.UserDefinedCalendarConfiguration;
+import org.jasig.portlet.calendar.dao.ICalendarSetDao;
+import org.jasig.portlet.calendar.mvc.IViewSelector;
+import org.jasig.portlet.calendar.service.IInitializationService;
+import org.joda.time.DateMidnight;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.springframework.mock.web.portlet.MockPortletSession;
+import org.springframework.mock.web.portlet.MockRenderRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.portlet.ModelAndView;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+
+public class CalendarControllerTest {
+
+	@Mock
+	private IInitializationService mockIInitializationService;
+	@Mock
+	private IViewSelector viewSelectorMock;
+	private ICalendarSetDao calendarDao;
+	private CalendarSet<UserDefinedCalendarConfiguration> calendarSet;
+	private CalendarController testee;
+	private MockRenderRequest mockRequest;
+	private MockPortletSession mockSession;
+	
+	@Before
+	public void startUp(){
+		mockRequest = new MockRenderRequest();
+		mockSession = new MockPortletSession();
+		initMocks(this);
+		calendarDao = new ICalendarSetDao() {
+			
+			@Override
+			public CalendarSet<?> getCalendarSet(PortletRequest request) {
+				return calendarSet;
+			}
+			
+			@Override
+			public List<PredefinedCalendarConfiguration> getAvailablePredefinedCalendarConfigurations(PortletRequest request) {
+				return null;
+			}
+		};
+		calendarSet = new CalendarSet<UserDefinedCalendarConfiguration>();
+		calendarSet.setConfigurations(Collections.emptySet());
+		testee = new CalendarController();
+		mockRequest.setSession(mockSession);
+		ReflectionTestUtils.setField(testee,"initializationServices",Collections.singletonList(mockIInitializationService));
+		ReflectionTestUtils.setField(testee,"calendarSetDao",calendarDao);
+		ReflectionTestUtils.setField(testee,"viewSelector",viewSelectorMock);
+	}
+	@Test
+	public void testDatePickerIsHiddenByDefault(){
+		when(viewSelectorMock.getCalendarViewName(eq(mockRequest))).thenReturn("calendar");
+		mockSession.setAttribute("startDate", new DateMidnight());
+		mockSession.setAttribute("days", 1);
+		ModelAndView mv = testee.getCalendar(null,mockRequest);
+		Map<String,Object> model = (Map<String, Object>) mv.getModel().get("model");
+		assertEquals("false",model.get("showDatePicker"));
+		
+	}
+}

--- a/src/test/java/org/jasig/portlet/calendar/util/MockView.java
+++ b/src/test/java/org/jasig/portlet/calendar/util/MockView.java
@@ -1,0 +1,40 @@
+package org.jasig.portlet.calendar.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.servlet.ViewRendererServlet;
+import org.springframework.web.servlet.view.AbstractView;
+
+public class MockView extends AbstractView {
+
+	/** Default content type. Copied from AbstractView. */
+	private static final String DEFAULT_CONTENT_TYPE = "text/html;charset=ISO-8859-1";
+
+	private Map<String, Object> model;
+
+	@Override
+	public String getContentType() {
+		return DEFAULT_CONTENT_TYPE;
+	}
+
+	@Override
+	protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request,
+			HttpServletResponse response) throws Exception {
+
+		this.model = model;
+
+		System.out.println(request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE));
+	}
+
+	public Map<String, Object> getModel() {
+		if (model == null) {
+			return new HashMap<String, Object>();
+		}
+		return model;
+	}
+
+}

--- a/src/test/java/org/jasig/portlet/calendar/util/MockViewResolver.java
+++ b/src/test/java/org/jasig/portlet/calendar/util/MockViewResolver.java
@@ -1,0 +1,27 @@
+package org.jasig.portlet.calendar.util;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.ViewResolver;
+
+public class MockViewResolver implements ViewResolver {
+
+	private String viewName;
+	private MockView view;
+
+	public View resolveViewName(String viewName, Locale locale) throws Exception {
+		this.viewName = viewName;
+		this.view = new MockView();
+		return view;
+	}
+
+	public String getViewName() {
+		return viewName;
+	}
+
+	public Map<String, Object> getModel() {
+		return view.getModel();
+	}
+}

--- a/src/test/java/org/jasig/portlet/calendar/util/MockWebApplication.java
+++ b/src/test/java/org/jasig/portlet/calendar/util/MockWebApplication.java
@@ -1,0 +1,29 @@
+package org.jasig.portlet.calendar.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Configures a mock {@link WebApplicationContext}.  Each test class (or parent class) using 
+ * {@link MockWebApplicationContextLoader} must be annotated with this.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface MockWebApplication {
+	/**
+	 * The location of the webapp directory relative to your project.
+	 * For maven users, this is generally src/main/webapp (default).
+	 */
+	String webapp() default "src/main/webapp";
+
+	/**
+	 * The portlet name
+	 */
+	String name();
+}

--- a/src/test/java/org/jasig/portlet/calendar/util/MockWebApplicationContextLoader.java
+++ b/src/test/java/org/jasig/portlet/calendar/util/MockWebApplicationContextLoader.java
@@ -1,0 +1,117 @@
+package org.jasig.portlet.calendar.util;
+
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.SourceFilteringListener;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.io.FileSystemResourceLoader;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.mock.web.portlet.MockPortletConfig;
+import org.springframework.mock.web.portlet.ServletWrappingPortletContext;
+import org.springframework.test.context.ContextLoader;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.support.AbstractContextLoader;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.portlet.DispatcherPortlet;
+import org.springframework.web.portlet.context.XmlPortletApplicationContext;
+import org.springframework.web.servlet.ViewResolver;
+
+/**
+ * A Spring {@link ContextLoader} that establishes a mock Portlet environment
+ * and {@link WebApplicationContext} so that Spring Portlet MVC stacks can be
+ * tested from within JUnit.
+ */
+public class MockWebApplicationContextLoader extends AbstractContextLoader {
+	/**
+	 * The configuration defined in the {@link MockWebApplication} annotation.
+	 */
+	private MockWebApplication configuration;
+
+	public ApplicationContext loadContext(String... locations) throws Exception {
+		// Establish the portlet context and config based on the test class's MockWebApplication annotation.
+		MockServletContext mockServletContext = new MockServletContext(configuration.webapp(), new FileSystemResourceLoader());
+		final ServletWrappingPortletContext portletContext = new ServletWrappingPortletContext(mockServletContext);
+		final MockPortletConfig portletConfig = new MockPortletConfig(portletContext, configuration.name());
+
+		// Create a WebApplicationContext and initialize it with the xml and portlet configuration.
+		final XmlPortletApplicationContext portletApplicationContext = new XmlPortletApplicationContext();
+		portletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, portletApplicationContext);
+		portletApplicationContext.setPortletConfig(portletConfig);
+		portletApplicationContext.setConfigLocations(locations);
+
+		// Create a DispatcherPortlet that uses the previously established WebApplicationContext.
+		final DispatcherPortlet dispatcherPortlet = new DispatcherPortlet() {
+			@Override
+			protected WebApplicationContext createPortletApplicationContext(ApplicationContext parent) {
+				return portletApplicationContext;
+			}
+		};
+
+		final ViewResolver viewResolver = new MockViewResolver();
+
+		// Add the DispatcherPortlet (and anything else you want) to the context.
+		// Note: this doesn't happen until refresh is called below.
+		portletApplicationContext.addBeanFactoryPostProcessor(new BeanFactoryPostProcessor() {
+			public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {
+				beanFactory.registerResolvableDependency(DispatcherPortlet.class, dispatcherPortlet);
+				// Register any other beans here, including a ViewResolver if you are using JSPs.
+				beanFactory.registerResolvableDependency(ViewResolver.class, viewResolver);
+			}
+		});
+
+		// Have the context notify the portlet every time it is refreshed.
+		portletApplicationContext.addApplicationListener(new SourceFilteringListener(portletApplicationContext,
+				new ApplicationListener<ContextRefreshedEvent>() {
+					public void onApplicationEvent(ContextRefreshedEvent event) {
+						dispatcherPortlet.onApplicationEvent(event);
+					}
+				}));
+
+		// Prepare the context.
+		portletApplicationContext.refresh();
+		portletApplicationContext.registerShutdownHook();
+
+		// Initialize the portlet.
+		dispatcherPortlet.setContextConfigLocation("");
+		dispatcherPortlet.init(portletConfig);
+
+		return portletApplicationContext;
+	}
+
+	/**
+	 * One of these two methods will get called before {@link #loadContext(String...)}. We just use this chance to extract the configuration.
+	 */
+	@Override
+	protected String[] generateDefaultLocations(Class<?> clazz) {
+		extractConfiguration(clazz);
+		return super.generateDefaultLocations(clazz);
+	}
+
+	/**
+	 * One of these two methods will get called before {@link #loadContext(String...)}. We just use this chance to extract the configuration.
+	 */
+	@Override
+	protected String[] modifyLocations(Class<?> clazz, String... locations) {
+		extractConfiguration(clazz);
+		return super.modifyLocations(clazz, locations);
+	}
+
+	private void extractConfiguration(Class<?> clazz) {
+		configuration = AnnotationUtils.findAnnotation(clazz, MockWebApplication.class);
+		if (configuration == null)
+			throw new IllegalArgumentException("Test class " + clazz.getName() + " must be annotated @MockWebApplication.");
+	}
+
+	@Override
+	protected String getResourceSuffix() {
+		return "-context.xml";
+	}
+
+	@Override
+	public ApplicationContext loadContext(MergedContextConfiguration mergedConfig) throws Exception {
+		return loadContext(mergedConfig.getLocations());
+	}
+}

--- a/src/test/resources/TestGetAvailabilitySoapMessage.xml
+++ b/src/test/resources/TestGetAvailabilitySoapMessage.xml
@@ -1,0 +1,26 @@
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+	<SOAP-ENV:Header>
+		<ns3:RequestServerVersion
+			xmlns:ns3="http://schemas.microsoft.com/exchange/services/2006/types"
+			Version="Exchange2010_SP1" />
+		<t:ExchangeImpersonation
+			xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+			<t:ConnectingSID>
+				<t:PrincipalName>o365st19@ed.ac.uk</t:PrincipalName>
+			</t:ConnectingSID>
+		</t:ExchangeImpersonation>
+	</SOAP-ENV:Header>
+	<SOAP-ENV:Body>
+		<ns2:FindItem
+			xmlns:ns2="http://schemas.microsoft.com/exchange/services/2006/messages"
+			xmlns:ns3="http://schemas.microsoft.com/exchange/services/2006/types"
+			Traversal="Shallow">
+			<ns2:ItemShape>
+				<ns3:BaseShape>AllProperties</ns3:BaseShape>
+			</ns2:ItemShape>
+			<ns2:ParentFolderIds>
+				<ns3:DistinguishedFolderId Id="inbox" />
+			</ns2:ParentFolderIds>
+		</ns2:FindItem>
+	</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/test/resources/application.test.properties
+++ b/src/test/resources/application.test.properties
@@ -1,0 +1,1 @@
+hibernate.connection.url=jdbc:hsqldb:mem:mymemdb

--- a/src/test/resources/exchangeTestContext.xml
+++ b/src/test/resources/exchangeTestContext.xml
@@ -28,7 +28,7 @@
     http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
-    <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
+    <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean" p:shared="true">
         <property name="configLocation">
             <value>classpath:ehcache-test.xml</value>
         </property>

--- a/src/test/resources/testApplicationContext.xml
+++ b/src/test/resources/testApplicationContext.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<!-- 	<import resource="classpath:applicationContext.xml" /> -->
+	
+	<import resource="file:src/main/webapp/WEB-INF/context/applicationContext.xml" />
+	<import resource="file:src/main/webapp/WEB-INF/context/portlet/calendar.xml" />
+	<import resource="file:src/main/webapp/WEB-INF/context/calendarContext.xml" />
+	<bean id="propertyConfigurer"
+		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
+		lazy-init="false">
+		<property name="locations">
+			<list>
+				<value>classpath:datasource.properties</value>
+				<value>classpath:configuration.properties</value>
+                <value>classpath:application.test.properties</value>
+			</list>
+		</property>
+	</bean>
+	<import resource="file:src/main/webapp/WEB-INF/context/databaseContext.xml" />
+	<!-- <import -->
+	<!-- resource="file:src/main/webapp/WEB-INF/context/databaseContext.xml" 
+		/> -->
+	<bean id="xmlviewresolver" class="org.jasig.portlet.calendar.util.MockViewResolver" /><!-- 
+		overwriting the real bean -->
+	<bean id="CacheExpiresFilter"
+		class="org.jasig.portlet.calendar.mvc.AggregationAwareFilterBean">
+
+	</bean>
+</beans>


### PR DESCRIPTION
master username and master password (which are used to log in to the
exchange server) need to be set in the portlet.xml preferences. All
users use these master values and their uportal username is the value
used for impersonation.
2) A bugfix for caching of calendar events; Etags are now part of the ajax
request url.
