### PR TITLE
CAP-159: Fix CalendarEventDao to only create CalendarDisplayEvents wh…

### DIFF
--- a/src/main/java/org/jasig/portlet/calendar/adapter/CalendarEventsDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/CalendarEventsDao.java
@@ -250,11 +250,12 @@ public class CalendarEventsDao {
             final Interval theSpecificDay = new Interval(startOfTheSpecificDay.getMillis(), endOfTheSpecificDay.getMillis(), usersConfiguredDateTimeZone);
 
             /*
-             * The test if the event interval has two parts: one more subtle than the other. The later test of overlaps()
-             * is an obvious test if the event happens in the specific day. The former test handles the special case
-             * where a zero-duration event abuts the specific day. The abuts() method checks to see if the intervals
-             * touch on either start or end of the interval. Here, we prefer to associate the event with the start of
-             * the next day instead of the end of the previous day.
+             * Test if the event interval abuts the start of the day or is within the day.
+             * This start time check is needed for the corner case where a zero duration interval
+             * is set for midnight.
+             * The start times are tested directly as opposed to using abuts() because that method
+             * also returns true if the intervals abut at the end of the day. We want to associate
+             * instant events that start at midnight with the starting day, not the ending day.
              */
             if (theSpecificDay.getStart().isEqual(eventStart) || theSpecificDay.overlaps(eventInterval)) {
                 final CalendarDisplayEvent json = new CalendarDisplayEvent(event, eventInterval, theSpecificDay, df, tf);

--- a/src/main/java/org/jasig/portlet/calendar/adapter/CalendarEventsDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/CalendarEventsDao.java
@@ -58,240 +58,236 @@ import org.springframework.context.MessageSource;
  */
 public class CalendarEventsDao {
 
-	protected final Log log = LogFactory.getLog(getClass());
+    protected final Log log = LogFactory.getLog(getClass());
 
-	private Cache cache;
+    private Cache cache;
 
-	/**
-	 * @param cache the cache to set
-	 */
-	@Required
-	public void setCache(Cache cache) {
-		this.cache = cache;
-	}
+    /**
+     * @param cache the cache to set
+     */
+    @Required
+    public void setCache(Cache cache) {
+        this.cache = cache;
+    }
 
-	private Map<String, DateTimeFormatter> dateFormatters = new ConcurrentHashMap<String, DateTimeFormatter>();
+    private Map<String, DateTimeFormatter> dateFormatters = new ConcurrentHashMap<String, DateTimeFormatter>();
 
-	private Map<String, DateTimeFormatter> timeFormatters = new ConcurrentHashMap<String, DateTimeFormatter>();
+    private Map<String, DateTimeFormatter> timeFormatters = new ConcurrentHashMap<String, DateTimeFormatter>();
 
-	private MessageSource messageSource;
-	/**
-	 * Setter of attribute messageSource.
-	 * @param messageSource the attribute messageSource to set
-	 */
-	@Required
-	public void setMessageSource(MessageSource messageSource) {
-		this.messageSource = messageSource;
-	}
+    private MessageSource messageSource;
+    /**
+     * Setter of attribute messageSource.
+     * @param messageSource the attribute messageSource to set
+     */
+    @Required
+    public void setMessageSource(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
 
-	public Calendar getCalendar(ICalendarAdapter adapter, CalendarConfiguration calendarConfig,
-			Interval interval, PortletRequest request) {
+    public Calendar getCalendar(ICalendarAdapter adapter, CalendarConfiguration calendarConfig,
+            Interval interval, PortletRequest request) {
 
-		// get the set of pre-timezone-corrected events for the requested period
-		// Rely on the adapter to do caching
-		final CalendarEventSet eventSet = adapter.getEvents(calendarConfig, interval, request);
+        // get the set of pre-timezone-corrected events for the requested period
+        // Rely on the adapter to do caching
+        final CalendarEventSet eventSet = adapter.getEvents(calendarConfig, interval, request);
 
-		// Create a calendar from the events
-		Calendar calendar = new Calendar();
-		calendar.getProperties().add(new ProdId("-//Ben Fortuna//iCal4j 1.0//EN"));
-		calendar.getProperties().add(Version.VERSION_2_0);
-		calendar.getProperties().add(CalScale.GREGORIAN);
+        // Create a calendar from the events
+        Calendar calendar = new Calendar();
+        calendar.getProperties().add(new ProdId("-//Ben Fortuna//iCal4j 1.0//EN"));
+        calendar.getProperties().add(Version.VERSION_2_0);
+        calendar.getProperties().add(CalScale.GREGORIAN);
 
-		for (VEvent event : eventSet.getEvents()) {
-			calendar.getComponents().add(event);
-		}
-		return calendar;
-	}
+        for (VEvent event : eventSet.getEvents()) {
+            calendar.getComponents().add(event);
+        }
+        return calendar;
+    }
 
-	/**
-	 * Obtains the calendar events from the adapter and returns timezone-adjusted
-	 * events within the requested interval.
-	 * @param adapter Adapter to invoke to obtain the calendar events
-	 * @param calendar Per-user Calendar configuration
-	 * @param interval Interval to return events for
-	 * @param request Portlet request
-	 * @param usersConfiguredDateTimeZone Timezone to adjust the calendar events to (typically the user's timezone)
-	 * @return Set of calendar events meeting the requested criteria
-	 */
-	public Set<CalendarDisplayEvent> getEvents(ICalendarAdapter adapter, CalendarConfiguration calendar,
-			Interval interval, PortletRequest request, DateTimeZone usersConfiguredDateTimeZone) {
+    /**
+     * Obtains the calendar events from the adapter and returns timezone-adjusted
+     * events within the requested interval.
+     * @param adapter Adapter to invoke to obtain the calendar events
+     * @param calendar Per-user Calendar configuration
+     * @param interval Interval to return events for
+     * @param request Portlet request
+     * @param usersConfiguredDateTimeZone Timezone to adjust the calendar events to (typically the user's timezone)
+     * @return Set of calendar events meeting the requested criteria
+     */
+    public Set<CalendarDisplayEvent> getEvents(ICalendarAdapter adapter, CalendarConfiguration calendar,
+            Interval interval, PortletRequest request, DateTimeZone usersConfiguredDateTimeZone) {
 
-		// Get the set of calendar events for the requested period.
-		// We invoke the adapter before checking cache because we expect the adapter
-		// to do the first-level caching of the events.
-		final CalendarEventSet eventSet = adapter.getEvents(calendar, interval, request);
+        // Get the set of calendar events for the requested period.
+        // We invoke the adapter before checking cache because we expect the adapter
+        // to do the first-level caching of the events.
+        final CalendarEventSet eventSet = adapter.getEvents(calendar, interval, request);
 
-		// The calendar events from the adapter will reflect the timezone of the calendar
-		// server in the event times.  The events need to be corrected to reflect the
-		// requested timezone (typically the user's timezone). Adjusting the
-		// event's timezone is an expensive operation so the JSON of the
-		// timezone-adjusted events is cached per timezone.
+        // The calendar events from the adapter will reflect the timezone of the calendar
+        // server in the event times.  The events need to be corrected to reflect the
+        // requested timezone (typically the user's timezone). Adjusting the
+        // event's timezone is an expensive operation so the JSON of the
+        // timezone-adjusted events is cached per timezone.
 
-		// Append the requested time zone id to the retrieve event set's cache
-		// key to generate a timezone-aware cache key
-		final String tzKey = eventSet.getKey().concat(usersConfiguredDateTimeZone.getID());
+        // Append the requested time zone id to the retrieve event set's cache
+        // key to generate a timezone-aware cache key
+        final String tzKey = eventSet.getKey().concat(usersConfiguredDateTimeZone.getID());
 
-		// attempt to retrieve the timezone-aware event set from cache
-		Element cachedElement = this.cache.get(tzKey);
-		if (cachedElement != null) {
-			if (log.isDebugEnabled()) {
-				log.debug("Retrieving JSON timezone-aware event set from cache, key:" + tzKey);
-			}
-			@SuppressWarnings("unchecked")
-			final Set<CalendarDisplayEvent> jsonEvents = (Set<CalendarDisplayEvent>) cachedElement.getValue();
-			return jsonEvents;
-		}
+        // attempt to retrieve the timezone-aware event set from cache
+        Element cachedElement = this.cache.get(tzKey);
+        if (cachedElement != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Retrieving JSON timezone-aware event set from cache, key:" + tzKey);
+            }
+            @SuppressWarnings("unchecked")
+            final Set<CalendarDisplayEvent> jsonEvents = (Set<CalendarDisplayEvent>) cachedElement.getValue();
+            return jsonEvents;
+        }
 
-		// if the timezone-corrected event set is not available in the cache
-		// generate a new set and cache it
-		else {
+        // if the timezone-corrected event set is not available in the cache
+        // generate a new set and cache it
+        else {
 
-			// for each event in the event set, generate a set of timezone-corrected
-			// event occurrences and add it to the new set
-			final Set<CalendarDisplayEvent> displayEvents = new HashSet<CalendarDisplayEvent>();
-			for (VEvent event : eventSet.getEvents()) {
-				try {
-					displayEvents.addAll(getDisplayEvents(event, interval, request.getLocale(), usersConfiguredDateTimeZone));
-				} catch (ParseException e) {
-					log.error("Exception parsing event", e);
-				} catch (IOException e) {
-					log.error("Exception parsing event", e);
-				} catch (URISyntaxException e) {
-					log.error("Exception parsing event", e);
-				} catch (IllegalArgumentException e) {
-					// todo fix the root problem. Just masking for the moment because no time to fix.
-					log.info("Likely invalid event returned from exchangeAdapter; see CAP-159");
-				}
-			}
+            // for each event in the event set, generate a set of timezone-corrected
+            // event occurrences and add it to the new set
+            final Set<CalendarDisplayEvent> displayEvents = new HashSet<CalendarDisplayEvent>();
+            for (VEvent event : eventSet.getEvents()) {
+                try {
+                    displayEvents.addAll(getDisplayEvents(event, interval, request.getLocale(), usersConfiguredDateTimeZone));
+                } catch (ParseException e) {
+                    log.error("Exception parsing event", e);
+                } catch (IOException e) {
+                    log.error("Exception parsing event", e);
+                } catch (URISyntaxException e) {
+                    log.error("Exception parsing event", e);
+                } catch (IllegalArgumentException e) {
+                    // todo fix the root problem. Just masking for the moment because no time to fix.
+                    log.info("Likely invalid event returned from exchangeAdapter; see CAP-159");
+                }
+            }
 
-			// Cache and return the resulting event list.  If the event set
-			// was cached, set the event list to expire at about the same time so it
-			// doesn't live in cache beyond the time the data it is derived
-			// from is considered up to date. Time to live is relative to the
-			// time the item is put into cache so the resulting event list will typically
-			// expire from 1 second before the event set to afterward by the amount
-			// of execution time from the adapter to displayEvents computation
-			// completing which should not be a big delta.
-			cachedElement = new Element(tzKey, displayEvents);
-			long currentTime = System.currentTimeMillis();
-			if (eventSet.getExpirationTime() > currentTime) {
-				long timeToLiveInMilliseconds =
-						eventSet.getExpirationTime() - currentTime;
-				int timeToLiveInSeconds = (int)timeToLiveInMilliseconds/1000;
-				cachedElement.setTimeToLive(timeToLiveInSeconds);
-				if (log.isDebugEnabled()) {
-					log.debug("Storing JSON timezone-aware event set to cache, key:" + tzKey
-							+ " with expiration in " + timeToLiveInSeconds + " seconds to"
-							+ " coincide with adapter's cache expiration time");
-				}
-			}
-			this.cache.put(cachedElement);
-			return displayEvents;
-		}
+            // Cache and return the resulting event list.  If the event set
+            // was cached, set the event list to expire at about the same time so it
+            // doesn't live in cache beyond the time the data it is derived
+            // from is considered up to date. Time to live is relative to the
+            // time the item is put into cache so the resulting event list will typically
+            // expire from 1 second before the event set to afterward by the amount
+            // of execution time from the adapter to displayEvents computation
+            // completing which should not be a big delta.
+            cachedElement = new Element(tzKey, displayEvents);
+            long currentTime = System.currentTimeMillis();
+            if (eventSet.getExpirationTime() > currentTime) {
+                long timeToLiveInMilliseconds =
+                        eventSet.getExpirationTime() - currentTime;
+                int timeToLiveInSeconds = (int)timeToLiveInMilliseconds/1000;
+                cachedElement.setTimeToLive(timeToLiveInSeconds);
+                if (log.isDebugEnabled()) {
+                    log.debug("Storing JSON timezone-aware event set to cache, key:" + tzKey
+                            + " with expiration in " + timeToLiveInSeconds + " seconds to"
+                            + " coincide with adapter's cache expiration time");
+                }
+            }
+            this.cache.put(cachedElement);
+            return displayEvents;
+        }
 
-	}
-
-
-	/**
-	 * Get a JSON-appropriate representation of each recurrence of an event
-	 * within the specified time period.
-	 *
-	 * @param e
-	 * @param interval
-	 * @param usersConfiguredDateTimeZone
-	 * @return
-	 * @throws IOException
-	 * @throws URISyntaxException
-	 * @throws ParseException
-	 */
-	protected Set<CalendarDisplayEvent> getDisplayEvents(VEvent e, Interval interval, Locale locale, DateTimeZone usersConfiguredDateTimeZone) throws IOException, URISyntaxException, ParseException {
-
-		final VEvent event = (VEvent) e.copy();
-
-		DateTime eventStart;
-		DateTime eventEnd = null;
-
-		if (event.getStartDate().getTimeZone() == null && !event.getStartDate().isUtc()) {
-			if (log.isDebugEnabled()) {
-				log.debug("Identified event " + event.getSummary() + " as a floating event");
-			}
-
-			int offset = usersConfiguredDateTimeZone.getOffset(event.getStartDate().getDate().getTime());
-			eventStart = new DateTime(event.getStartDate().getDate().getTime()-offset, usersConfiguredDateTimeZone);
-			if (event.getEndDate() != null) {
-				eventEnd = new DateTime(event.getEndDate().getDate().getTime()-offset, usersConfiguredDateTimeZone);
-			}
-
-		} else {
-			eventStart = new DateTime(event.getStartDate().getDate(), usersConfiguredDateTimeZone);
-			if (event.getEndDate() != null) {
-				eventEnd = new DateTime(event.getEndDate().getDate(), usersConfiguredDateTimeZone);
-			}
-		}
-
-		if (eventEnd == null) {
-			eventEnd = eventStart;
-		}
-
-		// Multi-day events may begin in the past;  make sure to choose a date in range for the first pass...
-		final Date firstDayToProcess = interval.contains(event.getStartDate().getDate().getTime())
-				? event.getStartDate().getDate()
-				: interval.getStart().toDate();
-
-		DateMidnight startOfTheSpecificDay = new DateMidnight(firstDayToProcess, usersConfiguredDateTimeZone);
-		DateMidnight endOfTheSpecificDay = startOfTheSpecificDay.plusDays(1);
-
-		final DateTimeFormatter df = getDateFormatter(locale, usersConfiguredDateTimeZone);
-		final DateTimeFormatter tf = getTimeFormatter(locale, usersConfiguredDateTimeZone);
-		final Set<CalendarDisplayEvent> events = new HashSet<CalendarDisplayEvent>();
-
-		do {
-			final Interval theSpecificDay = new Interval(startOfTheSpecificDay.getMillis(), endOfTheSpecificDay.getMillis(), usersConfiguredDateTimeZone);
-			final Interval eventInterval = new Interval(eventStart, eventEnd);
-
-			final CalendarDisplayEvent json = new CalendarDisplayEvent(event, eventInterval, theSpecificDay, df, tf);
+    }
 
 
-			// if the adjusted event still falls within the
-			// indicated period go ahead and add it to our list
+    /**
+     * Get a JSON-appropriate representation of each recurrence of an event
+     * within the specified time period.
+     *
+     * @param e
+     * @param interval
+     * @param usersConfiguredDateTimeZone
+     * @return
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws ParseException
+     */
+    protected Set<CalendarDisplayEvent> getDisplayEvents(VEvent e, Interval interval, Locale locale, DateTimeZone usersConfiguredDateTimeZone) throws IOException, URISyntaxException, ParseException {
 
-			// the event starts exactly at the day boundary
-			if (theSpecificDay.getStart().isEqual(eventStart)) {
-				events.add(json);
-			}
+        final VEvent event = (VEvent) e.copy();
 
-			// the event day overlaps this day
-			else if (theSpecificDay.overlaps(eventInterval)) {
-				events.add(json);
-			}
+        DateTime eventStart;
+        DateTime eventEnd = null;
 
-			startOfTheSpecificDay = startOfTheSpecificDay.plusDays(1);
-			endOfTheSpecificDay = endOfTheSpecificDay.plusDays(1);
+        if (event.getStartDate().getTimeZone() == null && !event.getStartDate().isUtc()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Identified event " + event.getSummary() + " as a floating event");
+            }
+
+            int offset = usersConfiguredDateTimeZone.getOffset(event.getStartDate().getDate().getTime());
+            eventStart = new DateTime(event.getStartDate().getDate().getTime()-offset, usersConfiguredDateTimeZone);
+            if (event.getEndDate() != null) {
+                eventEnd = new DateTime(event.getEndDate().getDate().getTime()-offset, usersConfiguredDateTimeZone);
+            }
+
+        } else {
+            eventStart = new DateTime(event.getStartDate().getDate(), usersConfiguredDateTimeZone);
+            if (event.getEndDate() != null) {
+                eventEnd = new DateTime(event.getEndDate().getDate(), usersConfiguredDateTimeZone);
+            }
+        }
+
+        if (eventEnd == null) {
+            eventEnd = eventStart;
+        }
+
+        // Multi-day events may begin in the past;  make sure to choose a date in range for the first pass...
+        final Date firstDayToProcess = interval.contains(event.getStartDate().getDate().getTime())
+                ? event.getStartDate().getDate()
+                : interval.getStart().toDate();
+
+        DateMidnight startOfTheSpecificDay = new DateMidnight(firstDayToProcess, usersConfiguredDateTimeZone);
+        DateMidnight endOfTheSpecificDay = startOfTheSpecificDay.plusDays(1);
+
+        final DateTimeFormatter df = getDateFormatter(locale, usersConfiguredDateTimeZone);
+        final DateTimeFormatter tf = getTimeFormatter(locale, usersConfiguredDateTimeZone);
+        final Set<CalendarDisplayEvent> events = new HashSet<CalendarDisplayEvent>();
+        final Interval eventInterval = new Interval(eventStart, eventEnd);
+
+        do {
+            final Interval theSpecificDay = new Interval(startOfTheSpecificDay.getMillis(), endOfTheSpecificDay.getMillis(), usersConfiguredDateTimeZone);
+
+            /*
+             * The test if the event interval has two parts: one more subtle than the other. The later test of overlaps()
+             * is an obvious test if the event happens in the specific day. The former test handles the special case
+             * where a zero-duration event abuts the specific day. The abuts() method checks to see if the intervals
+             * touch on either start or end of the interval. Here, we prefer to associate the event with the start of
+             * the next day instead of the end of the previous day.
+             */
+            if (theSpecificDay.getStart().isEqual(eventStart) || theSpecificDay.overlaps(eventInterval)) {
+                final CalendarDisplayEvent json = new CalendarDisplayEvent(event, eventInterval, theSpecificDay, df, tf);
+                events.add(json);
+            }
+
+            startOfTheSpecificDay = startOfTheSpecificDay.plusDays(1);
+            endOfTheSpecificDay = endOfTheSpecificDay.plusDays(1);
 
         } while (!startOfTheSpecificDay.isAfter(eventEnd) && interval.contains(startOfTheSpecificDay));
 
-		return events;
-	}
+        return events;
+    }
 
 
-	protected DateTimeFormatter getDateFormatter(Locale locale, DateTimeZone timezone) {
-		if (this.dateFormatters.containsKey(timezone.getID())) {
-			return this.dateFormatters.get(timezone.getID());
-		}
-		final String displayPattern = this.messageSource.getMessage("date.formatter.display", null, "EEE MMM d", locale);
-		DateTimeFormatter df = new DateTimeFormatterBuilder().appendPattern(displayPattern).toFormatter().withZone(timezone);
-		this.dateFormatters.put(timezone.getID(), df);
-		return df;
-	}
+    protected DateTimeFormatter getDateFormatter(Locale locale, DateTimeZone timezone) {
+        if (this.dateFormatters.containsKey(timezone.getID())) {
+            return this.dateFormatters.get(timezone.getID());
+        }
+        final String displayPattern = this.messageSource.getMessage("date.formatter.display", null, "EEE MMM d", locale);
+        DateTimeFormatter df = new DateTimeFormatterBuilder().appendPattern(displayPattern).toFormatter().withZone(timezone);
+        this.dateFormatters.put(timezone.getID(), df);
+        return df;
+    }
 
-	protected DateTimeFormatter getTimeFormatter(Locale locale, DateTimeZone timezone) {
-		if (this.timeFormatters.containsKey(timezone.getID())) {
-			return this.timeFormatters.get(timezone.getID());
-		}
-		final String displayPattern = this.messageSource.getMessage("time.formatter.display", null, "h:mm a", locale);
-		DateTimeFormatter tf = new DateTimeFormatterBuilder().appendPattern(displayPattern).toFormatter().withZone(timezone);
-		this.timeFormatters.put(timezone.getID(), tf);
-		return tf;
-	}
+    protected DateTimeFormatter getTimeFormatter(Locale locale, DateTimeZone timezone) {
+        if (this.timeFormatters.containsKey(timezone.getID())) {
+            return this.timeFormatters.get(timezone.getID());
+        }
+        final String displayPattern = this.messageSource.getMessage("time.formatter.display", null, "h:mm a", locale);
+        DateTimeFormatter tf = new DateTimeFormatterBuilder().appendPattern(displayPattern).toFormatter().withZone(timezone);
+        this.timeFormatters.put(timezone.getID(), tf);
+        return tf;
+    }
 
 }

--- a/src/main/java/org/jasig/portlet/calendar/mvc/CalendarDisplayEvent.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/CalendarDisplayEvent.java
@@ -41,11 +41,11 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
     private final DateTime dayEnd;
     private final boolean isAllDay;
     private final boolean isMultiDay;
-    
+
     private final String summary;
     private final String description;
     private final String location;
-    
+
     private final String dateStartTime;
     private final String dateEndTime;
     private final String startTime;
@@ -63,6 +63,7 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
      * @param tf time formatter to represent time displays
      */
     public CalendarDisplayEvent(VEvent event, Interval eventInterval, Interval theSpecificDay, DateTimeFormatter df, DateTimeFormatter tf) {
+        assert theSpecificDay.abuts(eventInterval) || theSpecificDay.overlaps(eventInterval) : "Event interval is not in the specified day!";
 
         this.summary = event.getSummary() != null ? event.getSummary().getValue() : null;
         this.description = event.getDescription() != null ? event.getDescription().getValue() : null;
@@ -75,7 +76,7 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
         } else {
             dayStart = eventInterval.getStart();
         }
-        
+
         if (event.getEndDate() == null) {
             dayEnd = dayStart;
         } else if (eventInterval.getEnd().isAfter(theSpecificDay.getEnd())) {
@@ -85,7 +86,7 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
             dayEnd = eventInterval.getEnd();
         }
         this.isMultiDay = multi;
-        
+
         this.dateStartTime = tf.print(dayStart);
         this.startTime = tf.print(eventInterval.getStart());
         this.startDate = df.print(eventInterval.getStart());
@@ -102,25 +103,25 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
 
         Interval dayEventInterval = new Interval(dayStart, dayEnd);
         this.isAllDay = dayEventInterval.equals(theSpecificDay);
-        
+
     }
-	
+
     public String getSummary() {
         return this.summary;
     }
-    
+
     public String getDescription() {
         return this.description;
     }
-    
+
     public String getLocation() {
         return this.location;
     }
-    
+
     public String getDateStartTime() {
         return this.dateStartTime;
     }
-    
+
     public String getDateEndTime() {
         return this.dateEndTime;
     }
@@ -128,7 +129,7 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
     public String getStartTime() {
         return this.startTime;
     }
-    
+
     public String getEndTime() {
         return this.endTime;
     }
@@ -136,7 +137,7 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
     public String getStartDate() {
         return this.startDate;
     }
-    
+
     public String getEndDate() {
         return this.endDate;
     }
@@ -144,11 +145,11 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
     public boolean isAllDay() {
         return this.isAllDay;
     }
-    
+
     public boolean isMultiDay() {
         return this.isMultiDay;
     }
-    
+
     public DateTime getDayStart() {
         return this.dayStart;
     }
@@ -157,9 +158,9 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
         return this.dayEnd;
     }
 
-    public int compareTo(CalendarDisplayEvent event) {      
+    public int compareTo(CalendarDisplayEvent event) {
         // Order events by start date, then end date, then summary.
-        // If all properties are equal, use the calendar and event ids to 
+        // If all properties are equal, use the calendar and event ids to
         // ensure similar events from different calendars are not misinterpreted
         // as identical.
         return (new CompareToBuilder())
@@ -167,7 +168,7 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
                 .append(this.dayEnd, event.dayEnd)
                 .append(this.getSummary(), event.getSummary())
                 // The UID class doesn't implement comparable and will give
-                // rise to a ClassCastException if it's actually tested. 
+                // rise to a ClassCastException if it's actually tested.
                 // .append(this.event.getUid(), event.event.getUid())
                 .toComparison();
     }
@@ -183,11 +184,11 @@ public class CalendarDisplayEvent implements Comparable<CalendarDisplayEvent> {
                 .append(this.dayEnd, event.dayEnd)
                 .append(this.getSummary(), event.getSummary())
                 // The UID class doesn't implement comparable and will give
-                // rise to a ClassCastException if it's actually tested. 
+                // rise to a ClassCastException if it's actually tested.
                 // .append(this.event.getUid(), event.event.getUid())
                 .isEquals();
     }
-    
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 31)


### PR DESCRIPTION
…en needed. Issue was that the dao was creating CalendarDisplayEvent objects, then testing if they fell into the day of interest. All the information needed for the decision is available before the object is created, so code changed to test first and only create the CDE object if needed. In the CDE object, their was an assumption that the event interval fell into the day of interest. This could cause a case where the end time was updated before start. Added an assert to confirm the times meet expectations.

Also, replaced tabs with spaces. Please use ?w=1 in URL to ignore whitespace changes. (See https://github.com/blog/967-github-secrets)