### PR TITLE
CAP-196 search exception with postgresql -- move session init code to interceptor

### DIFF
--- a/src/main/java/org/jasig/portlet/calendar/CalendarSet.java
+++ b/src/main/java/org/jasig/portlet/calendar/CalendarSet.java
@@ -23,20 +23,20 @@ import java.util.Set;
 
 /**
  * CalendarSet represents a collection of calendar configurations.
- * 
+ *
  * @author Jen Bourey, jbourey@unicon.net
  * @version $Revision$
  */
 public class CalendarSet<T extends CalendarConfiguration> {
-    
+
     private Set<T> configurations;
+
+    public CalendarSet(Set<T> configurations) {
+        this.configurations = configurations;
+    }
 
     public Set<T> getConfigurations() {
         return configurations;
     }
 
-    public void setConfigurations(Set<T> configurations) {
-        this.configurations = configurations;
-    }
-    
 }

--- a/src/main/java/org/jasig/portlet/calendar/dao/HibernateCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/HibernateCalendarSetDao.java
@@ -61,6 +61,8 @@ public class HibernateCalendarSetDao implements ICalendarSetDao {
     public CalendarSet<?> getCalendarSet(PortletRequest request) {
 
         final CalendarSet<UserDefinedCalendarConfiguration> set = new CalendarSet<UserDefinedCalendarConfiguration>();
+        final Set<UserDefinedCalendarConfiguration> calendars = new HashSet<UserDefinedCalendarConfiguration>();
+        set.setConfigurations(calendars);
 
         final String username = getUsername(request);
         if (username != null) {
@@ -69,10 +71,8 @@ public class HibernateCalendarSetDao implements ICalendarSetDao {
             final List<UserDefinedCalendarConfiguration> cals = calendarStore
                 .getCalendarConfigurations(username);
 
-            final Set<UserDefinedCalendarConfiguration> calendars = new HashSet<UserDefinedCalendarConfiguration>();
             calendars.addAll(cals);
 
-            set.setConfigurations(calendars);
         }
         return set;
     }

--- a/src/main/java/org/jasig/portlet/calendar/dao/HibernateCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/HibernateCalendarSetDao.java
@@ -73,6 +73,8 @@ public class HibernateCalendarSetDao implements ICalendarSetDao {
 
             calendars.addAll(cals);
 
+        } else {
+            log.warn("username is null -- returning empty calendar set");
         }
         return set;
     }
@@ -86,6 +88,7 @@ public class HibernateCalendarSetDao implements ICalendarSetDao {
             // For this ICalendarSetDao, the list is the unfiltered collection from CalendarStore...
             return calendarStore.getPredefinedCalendarConfigurations(username, false);
         } else {
+            log.warn("username is null -- returning empty calendar configuration list");
             return new ArrayList<PredefinedCalendarConfiguration>();
         }
     }

--- a/src/main/java/org/jasig/portlet/calendar/dao/HibernateCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/HibernateCalendarSetDao.java
@@ -60,9 +60,9 @@ public class HibernateCalendarSetDao implements ICalendarSetDao {
      */
     public CalendarSet<?> getCalendarSet(PortletRequest request) {
 
-        final CalendarSet<UserDefinedCalendarConfiguration> set = new CalendarSet<UserDefinedCalendarConfiguration>();
         final Set<UserDefinedCalendarConfiguration> calendars = new HashSet<UserDefinedCalendarConfiguration>();
-        set.setConfigurations(calendars);
+        final CalendarSet<UserDefinedCalendarConfiguration> set
+                = new CalendarSet<UserDefinedCalendarConfiguration>(calendars);
 
         final String username = getUsername(request);
         if (username != null) {

--- a/src/main/java/org/jasig/portlet/calendar/dao/PortletPreferencesCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/PortletPreferencesCalendarSetDao.java
@@ -39,22 +39,22 @@ import org.springframework.beans.factory.annotation.Required;
 import edu.emory.mathcs.backport.java.util.Collections;
 
 /**
- * PortletPreferencesCalendarSetDao provides a portlet preference-based 
+ * PortletPreferencesCalendarSetDao provides a portlet preference-based
  * implementation of the ICalendarSetDao interface.  This implementation is
  * currently very limited and does not support the addition of user editing or
  * configuration or interact with any of the roles features.
- * 
+ *
  * @author Jen Bourey, jbourey@unicon.net
  * @deprecated Use {@link WhitelistFilteringCalendarSetDao} instead.
  */
 public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
-    
+
     private static final String CALENDAR_FNAME_KEY = "calendarFnames";
     private static final String CALENDAR_SET_KEY = "PortletPreferencesCalendarSetDao.CALENDAR_SET_KEY";
-    
+
     private CalendarStore calendarStore;
     private final Log log = LogFactory.getLog(getClass());
-    
+
     @Resource(name="calendarStore")
     @Required
     public void setCalendarStore(CalendarStore calendarStore) {
@@ -67,9 +67,9 @@ public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
      */
     @SuppressWarnings("unchecked")
     public CalendarSet<CalendarConfiguration> getCalendarSet(PortletRequest request) {
-        
+
         // Check the PortletSession, create if we don't have one;
-        // This strategy prevents the configuration ids from being 
+        // This strategy prevents the configuration ids from being
         // reordered between requests.
         PortletSession session = request.getPortletSession();
         CalendarSet<CalendarConfiguration> rslt = (CalendarSet<CalendarConfiguration>) session.getAttribute(CALENDAR_SET_KEY);
@@ -78,9 +78,9 @@ public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
             session.setAttribute(CALENDAR_SET_KEY, rslt);
         }
         return rslt;
-        
+
     }
-    
+
     @SuppressWarnings("unchecked")
     @Override
     public List<PredefinedCalendarConfiguration> getAvailablePredefinedCalendarConfigurations(PortletRequest request) {
@@ -91,9 +91,9 @@ public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
     /*
      * Implementation
      */
-    
+
     private CalendarSet<CalendarConfiguration> createCalendarSet(PortletRequest request) {
-        
+
         if (log.isDebugEnabled()) {
             log.debug("Evaluating CalendarSet for user:  " + request.getRemoteUser());
         }
@@ -101,7 +101,7 @@ public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
         // get the calendar fname array from the portlet preferences
         PortletPreferences preferences = request.getPreferences();
         String[] calendarFnames = preferences.getValues(CALENDAR_FNAME_KEY, new String[]{});
-        
+
         if (log.isDebugEnabled()) {
             StringBuilder msg = new StringBuilder();
             msg.append("Found the following calendarFnames in PortletPreferences:  ");
@@ -110,13 +110,13 @@ public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
             }
             log.debug(msg.toString());
         }
-        
+
         // for each configured fname, attempt to find the relevant predefined
         // calendar definition and create a default configuration for it
         Set<CalendarConfiguration> calendars = new HashSet<CalendarConfiguration>();
         long nextId = 0;
         for (String fname : calendarFnames) {
-            
+
             // attempt to locate the calendar definition associated with
             // this fname
             CalendarDefinition definition = null;
@@ -125,7 +125,7 @@ public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
             } catch (Exception e) {
                 log.error("Failed to retrieve calendar definition with fname " + fname);
             }
-            
+
             // if we found a definition, add a configuration to the list
             if (definition != null) {
                 PredefinedCalendarConfiguration config = new PredefinedCalendarConfiguration();
@@ -134,10 +134,9 @@ public final class PortletPreferencesCalendarSetDao implements ICalendarSetDao {
                 calendars.add(config);
             }
         }
-        
+
         // create a new calendar set from these configurations
-        CalendarSet<CalendarConfiguration> set = new CalendarSet<CalendarConfiguration>();
-        set.setConfigurations(calendars);
+        CalendarSet<CalendarConfiguration> set = new CalendarSet<CalendarConfiguration>(calendars);
         return set;
 
     }

--- a/src/main/java/org/jasig/portlet/calendar/dao/WhitelistFilteringCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/WhitelistFilteringCalendarSetDao.java
@@ -35,30 +35,30 @@ import org.jasig.portlet.calendar.PredefinedCalendarDefinition;
 import edu.emory.mathcs.backport.java.util.Arrays;
 
 /**
- * Decorates another instance of {@link ICalendarSetDao} and filters the results 
+ * Decorates another instance of {@link ICalendarSetDao} and filters the results
  * it provides by the specified whitelist, unless the list is empty.  In that
  * case all results will be displayed.
- * 
+ *
  * @author awills
  */
 public class WhitelistFilteringCalendarSetDao implements ICalendarSetDao {
-    
+
     private ICalendarSetDao enclosedCalendarSetDao;
-    
+
     public void setEnclosedCalendarSetDao(ICalendarSetDao enclosedCalendarSetDao) {
         this.enclosedCalendarSetDao = enclosedCalendarSetDao;
     }
 
     /**
-     * If this preference is non-empty, only calendar-definitions whose fnames 
+     * If this preference is non-empty, only calendar-definitions whose fnames
      * appear in the whitelist will be shown.
      */
     private static final String CALENDAR_WHITELIST_PREFERENCE = "calendarWhitelist";
 
     @Override
     public CalendarSet<?> getCalendarSet(PortletRequest req) {
-        
-        final CalendarSet<? extends CalendarConfiguration> unmodifiedSet = 
+
+        final CalendarSet<? extends CalendarConfiguration> unmodifiedSet =
                 enclosedCalendarSetDao.getCalendarSet(req);
 
         final List<String> whitelist = getWhitelist(req);
@@ -66,41 +66,40 @@ public class WhitelistFilteringCalendarSetDao implements ICalendarSetDao {
             // No filtering to do...
             return unmodifiedSet;
         }
-        
+
         /*
-         * A whitelist of allowed calender-definition fnames has been defined, 
+         * A whitelist of allowed calender-definition fnames has been defined,
          * so we must filter out calendar-definitions that are not on the list
          */
-        
+
         final Set<CalendarConfiguration> configurations = new HashSet<CalendarConfiguration>();
 
-        final Set<? extends CalendarConfiguration> rawSet = unmodifiedSet.getConfigurations(); 
+        final Set<? extends CalendarConfiguration> rawSet = unmodifiedSet.getConfigurations();
         for (CalendarConfiguration config : rawSet) {
             if (config.getCalendarDefinition() instanceof PredefinedCalendarDefinition) {
-                final PredefinedCalendarDefinition pdef = (PredefinedCalendarDefinition) 
+                final PredefinedCalendarDefinition pdef = (PredefinedCalendarDefinition)
                         config.getCalendarDefinition();
                 // Make sure it appears on the whitelist
                 if (whitelist.contains(pdef.getFname())) {
                     configurations.add(config);
                 }
             } else {
-                // User-defined calendar-definitions always pass through;  if you 
+                // User-defined calendar-definitions always pass through;  if you
                 // intend to prevent them, set disablePreferences to 'true'
                 configurations.add(config);
             }
         }
-        
-        final CalendarSet<CalendarConfiguration> rslt = new CalendarSet<CalendarConfiguration>();
-        rslt.setConfigurations(configurations);
+
+        final CalendarSet<CalendarConfiguration> rslt = new CalendarSet<CalendarConfiguration>(configurations);
         return rslt;
-    
+
     }
 
     @Override
     public List<PredefinedCalendarConfiguration> getAvailablePredefinedCalendarConfigurations(
             PortletRequest req) {
 
-        final List<PredefinedCalendarConfiguration> unmodifiedList = 
+        final List<PredefinedCalendarConfiguration> unmodifiedList =
                 enclosedCalendarSetDao.getAvailablePredefinedCalendarConfigurations(req);
 
         final List<String> whitelist = getWhitelist(req);
@@ -110,14 +109,14 @@ public class WhitelistFilteringCalendarSetDao implements ICalendarSetDao {
         }
 
         /*
-         * A whitelist of allowed calender-definition fnames has been defined, 
+         * A whitelist of allowed calender-definition fnames has been defined,
          * so we must filter out calendar-definitions that are not on the list
          */
 
         final List<PredefinedCalendarConfiguration> rslt = new ArrayList<PredefinedCalendarConfiguration>();
 
         for (PredefinedCalendarConfiguration config :  unmodifiedList) {
-            final PredefinedCalendarDefinition pdef = (PredefinedCalendarDefinition) 
+            final PredefinedCalendarDefinition pdef = (PredefinedCalendarDefinition)
                     config.getCalendarDefinition();
             if (whitelist.contains(pdef.getFname())) {
                 rslt.add(config);
@@ -125,13 +124,13 @@ public class WhitelistFilteringCalendarSetDao implements ICalendarSetDao {
         }
 
         return rslt;
-        
+
     }
 
     /*
      * Implementation
      */
-    
+
     private List<String> getWhitelist(PortletRequest req) {
         final PortletPreferences prefs = req.getPreferences();
         @SuppressWarnings("unchecked")

--- a/src/main/java/org/jasig/portlet/calendar/mvc/UserSessionInitializer.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/UserSessionInitializer.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.calendar.mvc;
+
+import org.jasig.portlet.calendar.service.IInitializationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.portlet.HandlerInterceptor;
+import org.springframework.web.portlet.ModelAndView;
+
+import javax.portlet.*;
+import java.util.List;
+
+
+/**
+ * {code PortletFilter} to run initialization code when a user session is first created.
+ *
+ * @author Benito J. Gonzalez <bgonzalez2@unicon.net>
+ * @since 3.0.1
+ */
+public class UserSessionInitializer implements HandlerInterceptor {
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private List<IInitializationService> initializationServices;
+
+    public void setInitializationServices(List<IInitializationService> initializationServices) {
+        this.initializationServices = initializationServices;
+    }
+
+    private void callInitializers(PortletRequest request) {
+        PortletSession session = request.getPortletSession(true);
+        if (session.getAttribute("initialized") == null) {
+            log.info("initializing session for {}", request.getRemoteUser());
+            for (IInitializationService service : initializationServices) {
+                try {
+                    log.info("calling initialize(request) on {}", service.getClass().toString());
+                    service.initialize(request);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Issue with initialize call in filter: ", service.getClass());
+                }
+            }
+        }
+
+    }
+
+    @Override
+    public boolean preHandleAction(ActionRequest actionRequest, ActionResponse actionResponse, Object o) throws Exception {
+        callInitializers(actionRequest);
+        return true;
+    }
+
+    @Override
+    public void afterActionCompletion(ActionRequest actionRequest, ActionResponse actionResponse, Object o, Exception e) throws Exception {
+
+    }
+
+    @Override
+    public boolean preHandleRender(RenderRequest renderRequest, RenderResponse renderResponse, Object o) throws Exception {
+        callInitializers(renderRequest);
+        return true;
+    }
+
+    @Override
+    public void postHandleRender(RenderRequest renderRequest, RenderResponse renderResponse, Object o, ModelAndView modelAndView) throws Exception {
+
+    }
+
+    @Override
+    public void afterRenderCompletion(RenderRequest renderRequest, RenderResponse renderResponse, Object o, Exception e) throws Exception {
+
+    }
+
+    @Override
+    public boolean preHandleResource(ResourceRequest resourceRequest, ResourceResponse resourceResponse, Object o) throws Exception {
+        callInitializers(resourceRequest);
+        return true;
+    }
+
+    @Override
+    public void postHandleResource(ResourceRequest resourceRequest, ResourceResponse resourceResponse, Object o, ModelAndView modelAndView) throws Exception {
+
+    }
+
+    @Override
+    public void afterResourceCompletion(ResourceRequest resourceRequest, ResourceResponse resourceResponse, Object o, Exception e) throws Exception {
+
+    }
+
+    @Override
+    public boolean preHandleEvent(EventRequest eventRequest, EventResponse eventResponse, Object o) throws Exception {
+        callInitializers(eventRequest);
+        return true;
+    }
+
+    @Override
+    public void afterEventCompletion(EventRequest eventRequest, EventResponse eventResponse, Object o, Exception e) throws Exception {
+
+    }
+}

--- a/src/main/java/org/jasig/portlet/calendar/mvc/controller/CalendarController.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/controller/CalendarController.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Resource;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletSession;
 import javax.portlet.RenderRequest;
@@ -40,14 +39,12 @@ import org.jasig.portlet.calendar.adapter.CalendarLinkException;
 import org.jasig.portlet.calendar.adapter.ICalendarAdapter;
 import org.jasig.portlet.calendar.dao.ICalendarSetDao;
 import org.jasig.portlet.calendar.mvc.IViewSelector;
-import org.jasig.portlet.calendar.service.IInitializationService;
 import org.joda.time.DateMidnight;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Controller;
@@ -59,66 +56,71 @@ import org.springframework.web.portlet.bind.annotation.ActionMapping;
 @Controller
 @RequestMapping("VIEW")
 public class CalendarController implements ApplicationContextAware {
-    
+
     public static final String PREFERENCE_DISABLE_PREFERENCES = "disablePreferences";
     public static final String PREFERENCE_DISABLE_ADMINISTRATION = "disableAdministration";
 
-	protected final Log log = LogFactory.getLog(this.getClass());
+    protected final Log log = LogFactory.getLog(this.getClass());
 
-	@ActionMapping
-	public void defaultAction() { 
-	    // default action mapping
-	}
-	
-	@RequestMapping
-	public ModelAndView getCalendar(@RequestParam(required=false,value="interval") String intervalString,RenderRequest request) {
-		
-		/**
-		 * If this is a new session, perform any necessary 
-		 * portlet initialization.
-		 */
+    @Autowired
+    private ICalendarSetDao calendarSetDao;
 
-		PortletSession session = request.getPortletSession(true);
-		if (session.getAttribute("initialized") == null) {
-			
-			// perform any other configured initialization tasks
-			for (IInitializationService service : initializationServices) {
-				service.initialize(request);
-			}
-		}
+    @Autowired
+    private IViewSelector viewSelector;
+
+    private ApplicationContext applicationContext;
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.context.ApplicationContextAware#setApplicationContext(org.springframework.context.ApplicationContext)
+     */
+    public void setApplicationContext(ApplicationContext applicationContext)
+            throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @ActionMapping
+    public void defaultAction() {
+        // default action mapping
+    }
+
+    @RequestMapping
+    public ModelAndView getCalendar(@RequestParam(required=false,value="interval") String intervalString,RenderRequest request) {
+
+        PortletSession session = request.getPortletSession(true);
 
         PortletPreferences prefs = request.getPreferences();
 
-		Map<String, Object> model = new HashMap<String, Object>();
-		
-		// get the list of hidden calendars
-		@SuppressWarnings("unchecked")
-		HashMap<Long, String> hiddenCalendars = (HashMap<Long, String>) session
-				.getAttribute("hiddenCalendars");
+        Map<String, Object> model = new HashMap<String, Object>();
 
-		// indicate if the current user is a guest (unauthenticated) user
-		model.put("guest", request.getRemoteUser() == null);
-		
-		/**
-		 * Add and remove calendars from the hidden list.  Hidden calendars
-		 * will be fetched, but rendered invisible in the view.
-		 */
+        // get the list of hidden calendars
+        @SuppressWarnings("unchecked")
+        HashMap<Long, String> hiddenCalendars = (HashMap<Long, String>) session
+                .getAttribute("hiddenCalendars");
 
-		// check the request parameters to see if we need to add any
-		// calendars to the list of hidden calendars
-		String hideCalendar = request.getParameter("hideCalendar");
-		if (hideCalendar != null) {
-			hiddenCalendars.put(Long.valueOf(hideCalendar), "true");
-			session.setAttribute("hiddenCalendars", hiddenCalendars);
-		}
+        // indicate if the current user is a guest (unauthenticated) user
+        model.put("guest", request.getRemoteUser() == null);
 
-		// check the request parameters to see if we need to remove
-		// any calendars from the list of hidden calendars
-		String showCalendar = request.getParameter("showCalendar");
-		if (showCalendar != null) {
-			hiddenCalendars.remove(Long.valueOf(showCalendar));
-			session.setAttribute("hiddenCalendars", hiddenCalendars);
-		}
+        /**
+         * Add and remove calendars from the hidden list.  Hidden calendars
+         * will be fetched, but rendered invisible in the view.
+         */
+
+        // check the request parameters to see if we need to add any
+        // calendars to the list of hidden calendars
+        String hideCalendar = request.getParameter("hideCalendar");
+        if (hideCalendar != null) {
+            hiddenCalendars.put(Long.valueOf(hideCalendar), "true");
+            session.setAttribute("hiddenCalendars", hiddenCalendars);
+        }
+
+        // check the request parameters to see if we need to remove
+        // any calendars from the list of hidden calendars
+        String showCalendar = request.getParameter("showCalendar");
+        if (showCalendar != null) {
+            hiddenCalendars.remove(Long.valueOf(showCalendar));
+            session.setAttribute("hiddenCalendars", hiddenCalendars);
+        }
 
         // See if we're configured to show or hide the jQueryUI DatePicker.
         // By default, we assume we are to show the DatePicker because that's
@@ -126,9 +128,9 @@ public class CalendarController implements ApplicationContextAware {
         String showDatePicker = prefs.getValue( "showDatePicker", "true" );
         model.put( "showDatePicker", showDatePicker );
 
-		/**
-		 * Find our desired starting and ending dates.
-		 */
+        /**
+         * Find our desired starting and ending dates.
+         */
 
         Interval interval = null;
 
@@ -139,123 +141,90 @@ public class CalendarController implements ApplicationContextAware {
             model.put("days",interval.toDuration().getStandardDays());
             model.put("endDate",new DateMidnight(interval.getEnd()));
         } else {
-		    //StartDate can only be changed via an AJAX request
-		    DateMidnight startDate = (DateMidnight) session.getAttribute("startDate");
-		    log.debug("startDate from session is: "+startDate);
-		    model.put("startDate", startDate.toDate());
+            //StartDate can only be changed via an AJAX request
+            DateMidnight startDate = (DateMidnight) session.getAttribute("startDate");
+            log.debug("startDate from session is: "+startDate);
+            model.put("startDate", startDate.toDate());
 
-		    // find how many days into the future we should display events
-		    int days = (Integer) session.getAttribute("days");
-		    model.put("days", days);
+            // find how many days into the future we should display events
+            int days = (Integer) session.getAttribute("days");
+            model.put("days", days);
 
-		    // set the end date based on our desired time period
-		    DateMidnight endDate = startDate.plusDays(days);
-		    model.put("endDate", endDate.toDate());
+            // set the end date based on our desired time period
+            DateMidnight endDate = startDate.plusDays(days);
+            model.put("endDate", endDate.toDate());
 
-		    interval = new Interval(startDate, endDate);
+            interval = new Interval(startDate, endDate);
         }
 
-		// define "today" and "tomorrow" so we can display these specially in the
-		// user interface
+        // define "today" and "tomorrow" so we can display these specially in the
+        // user interface
         // get the user's configured time zone
         String timezone = (String) session.getAttribute("timezone");
-		DateMidnight today = new DateMidnight(DateTimeZone.forID(timezone));
-		model.put("today", today.toDate());
-		model.put("tomorrow", today.plusDays(1).toDate());
+        DateMidnight today = new DateMidnight(DateTimeZone.forID(timezone));
+        model.put("today", today.toDate());
+        model.put("tomorrow", today.plusDays(1).toDate());
 
-		/**
-		 * retrieve the calendars defined for this portlet instance
-		 */
-		
+        /**
+         * retrieve the calendars defined for this portlet instance
+         */
+
         CalendarSet<?> set = calendarSetDao.getCalendarSet(request);
         List<CalendarConfiguration> calendars = new ArrayList<CalendarConfiguration>();
         calendars.addAll(set.getConfigurations());
         Collections.sort(calendars, new CalendarConfigurationByNameComparator());
-		model.put("calendars", calendars);
+        model.put("calendars", calendars);
 
-		Map<Long, Integer> colors = new HashMap<Long, Integer>();
-		Map<Long, String> links = new HashMap<Long, String>();
-		int index = 0;
-		for (CalendarConfiguration callisting : calendars) {
+        Map<Long, Integer> colors = new HashMap<Long, Integer>();
+        Map<Long, String> links = new HashMap<Long, String>();
+        int index = 0;
+        for (CalendarConfiguration callisting : calendars) {
 
-			// don't bother to fetch hidden calendars
-			if (hiddenCalendars.get(callisting.getId()) == null) {
+            // don't bother to fetch hidden calendars
+            if (hiddenCalendars.get(callisting.getId()) == null) {
 
-				try {
-	
-					// get an instance of the adapter for this calendar
-					ICalendarAdapter adapter = (ICalendarAdapter) applicationContext.getBean(callisting
-							.getCalendarDefinition().getClassName());
-	
-					//get hyperlink to calendar
+                try {
+
+                    // get an instance of the adapter for this calendar
+                    ICalendarAdapter adapter = (ICalendarAdapter) applicationContext.getBean(callisting
+                            .getCalendarDefinition().getClassName());
+
+                    //get hyperlink to calendar
                     String link = adapter.getLink(callisting, interval, request);
-					if (link != null) {
+                    if (link != null) {
                         links.put(callisting.getId(), link);
                     }
-					
-				} catch (NoSuchBeanDefinitionException ex) {
-					log.error("Calendar class instance could not be found: " + ex.getMessage());
-				} catch (CalendarLinkException linkEx) {
+
+                } catch (NoSuchBeanDefinitionException ex) {
+                    log.error("Calendar class instance could not be found: " + ex.getMessage());
+                } catch (CalendarLinkException linkEx) {
                     // Not an error. Ignore
-				} catch (Exception ex) {
-					log.error(ex);
-				}
-			}
+                } catch (Exception ex) {
+                    log.error(ex);
+                }
+            }
 
-			// add this calendar's id to the color map
-			colors.put(callisting.getId(), index);
-			index++;
+            // add this calendar's id to the color map
+            colors.put(callisting.getId(), index);
+            index++;
 
-		}
+        }
 
-		model.put("timezone", session.getAttribute("timezone"));
-		model.put("colors", colors);
-		model.put("links", links);
-		model.put("hiddenCalendars", hiddenCalendars);
-		
-		/*
-		 * Check if we need to disable either the preferences and/or administration links
-		 */
-		
+        model.put("timezone", session.getAttribute("timezone"));
+        model.put("colors", colors);
+        model.put("links", links);
+        model.put("hiddenCalendars", hiddenCalendars);
+
+        /*
+         * Check if we need to disable either the preferences and/or administration links
+         */
+
         Boolean disablePrefs = Boolean.valueOf(prefs.getValue(PREFERENCE_DISABLE_PREFERENCES, "false"));
         model.put(PREFERENCE_DISABLE_PREFERENCES, disablePrefs);
         Boolean disableAdmin = Boolean.valueOf(prefs.getValue(PREFERENCE_DISABLE_ADMINISTRATION, "false"));
         model.put(PREFERENCE_DISABLE_ADMINISTRATION, disableAdmin);
-        
-		return new ModelAndView(viewSelector.getCalendarViewName(request), "model", model);
-	}
 
-    private ICalendarSetDao calendarSetDao;
-    
-    @Autowired(required = true)
-    public void setCalendarSetDao(ICalendarSetDao calendarSetDao) {
-        this.calendarSetDao = calendarSetDao;
+        return new ModelAndView(viewSelector.getCalendarViewName(request), "model", model);
     }
-
-	private List<IInitializationService> initializationServices;
-	
-	@Required
-	@Resource(name="initializationServices")
-	public void setInitializationServices(List<IInitializationService> services) {
-		this.initializationServices = services;
-	}
-	
-	private IViewSelector viewSelector;
-	
-	@Autowired(required=true)
-	public void setViewSelector(IViewSelector viewSelector) {
-		this.viewSelector = viewSelector;
-	}
-	
-	private ApplicationContext applicationContext;
-	
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.context.ApplicationContextAware#setApplicationContext(org.springframework.context.ApplicationContext)
-	 */
-	public void setApplicationContext(ApplicationContext applicationContext)
-			throws BeansException {
-		this.applicationContext = applicationContext;
-	}
 
 }

--- a/src/main/webapp/WEB-INF/context/portlet/calendar.xml
+++ b/src/main/webapp/WEB-INF/context/portlet/calendar.xml
@@ -27,7 +27,7 @@
        xmlns:p="http://www.springframework.org/schema/p"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
     http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd  
+    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
     <context:component-scan base-package="org.jasig.portlet.calendar.mvc"/>
@@ -93,7 +93,13 @@
     </util:map>
 
     <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
-        <property name="interceptors"><bean class="org.jasig.portlet.calendar.mvc.MinimizedStateHandlerInterceptor"/></property>
+        <property name="interceptors">
+            <list>
+                <bean class="org.jasig.portlet.calendar.mvc.MinimizedStateHandlerInterceptor"/>
+                <bean class="org.jasig.portlet.calendar.mvc.UserSessionInitializer"
+                        p:initializationServices-ref="initializationServices"/>
+            </list>
+        </property>
     </bean>
 
 </beans>

--- a/src/test/java/org/jasig/portlet/calendar/mvc/controller/CalendarControllerTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/mvc/controller/CalendarControllerTest.java
@@ -11,7 +11,6 @@ import org.jasig.portlet.calendar.PredefinedCalendarConfiguration;
 import org.jasig.portlet.calendar.UserDefinedCalendarConfiguration;
 import org.jasig.portlet.calendar.dao.ICalendarSetDao;
 import org.jasig.portlet.calendar.mvc.IViewSelector;
-import org.jasig.portlet.calendar.service.IInitializationService;
 import org.joda.time.DateMidnight;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,8 +27,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class CalendarControllerTest {
 
-	@Mock
-	private IInitializationService mockIInitializationService;
 	@Mock
 	private IViewSelector viewSelectorMock;
 	private ICalendarSetDao calendarDao;
@@ -58,7 +55,6 @@ public class CalendarControllerTest {
 		calendarSet = new CalendarSet<UserDefinedCalendarConfiguration>(Collections.emptySet());
 		testee = new CalendarController();
 		mockRequest.setSession(mockSession);
-		ReflectionTestUtils.setField(testee,"initializationServices",Collections.singletonList(mockIInitializationService));
 		ReflectionTestUtils.setField(testee,"calendarSetDao",calendarDao);
 		ReflectionTestUtils.setField(testee,"viewSelector",viewSelectorMock);
 	}

--- a/src/test/java/org/jasig/portlet/calendar/mvc/controller/CalendarControllerTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/mvc/controller/CalendarControllerTest.java
@@ -37,26 +37,25 @@ public class CalendarControllerTest {
 	private CalendarController testee;
 	private MockRenderRequest mockRequest;
 	private MockPortletSession mockSession;
-	
+
 	@Before
 	public void startUp(){
 		mockRequest = new MockRenderRequest();
 		mockSession = new MockPortletSession();
 		initMocks(this);
 		calendarDao = new ICalendarSetDao() {
-			
+
 			@Override
 			public CalendarSet<?> getCalendarSet(PortletRequest request) {
 				return calendarSet;
 			}
-			
+
 			@Override
 			public List<PredefinedCalendarConfiguration> getAvailablePredefinedCalendarConfigurations(PortletRequest request) {
 				return null;
 			}
 		};
-		calendarSet = new CalendarSet<UserDefinedCalendarConfiguration>();
-		calendarSet.setConfigurations(Collections.emptySet());
+		calendarSet = new CalendarSet<UserDefinedCalendarConfiguration>(Collections.emptySet());
 		testee = new CalendarController();
 		mockRequest.setSession(mockSession);
 		ReflectionTestUtils.setField(testee,"initializationServices",Collections.singletonList(mockIInitializationService));
@@ -71,6 +70,6 @@ public class CalendarControllerTest {
 		ModelAndView mv = testee.getCalendar(null,mockRequest);
 		Map<String,Object> model = (Map<String, Object>) mv.getModel().get("model");
 		assertEquals("true",model.get("showDatePicker"));
-		
+
 	}
 }


### PR DESCRIPTION
Currently, user session information is populated by CalendarController. If another controller is hit, say from performing a search in portal, before calendar is visited, user session is not set.

Pulling the user session initialization code out from the CalendarController into an interceptor.