### PR TITLE
Caldav4j moved to github

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <repository>
             <id>caldav4j.repo</id>
             <name>CalDav4J Repository</name>
-            <url>https://github.com/caldav4j/maven</url>
+            <url>https://github.com/caldav4j/maven/tree/master/repo/</url>
         </repository>
     </repositories>
     
@@ -292,7 +292,7 @@
                 <version>${mockito.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.osaf</groupId>
+                <groupId>com.github.caldav4j</groupId>
                 <artifactId>caldav4j</artifactId>
                 <version>0.7</version>
                 <exclusions>
@@ -373,7 +373,7 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
-                <groupId>slide</groupId>
+                <groupId>com.github.caldav4j</groupId>
                 <artifactId>jakarta-slide-webdavlib</artifactId>
                 <version>2.2pre1-httpclient-3.0</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <repository>
             <id>caldav4j.repo</id>
             <name>CalDav4J Repository</name>
-            <url>http://caldav4j.googlecode.com/svn/maven/</url>
+            <url>https://github.com/caldav4j/maven</url>
         </repository>
     </repositories>
     


### PR DESCRIPTION
Caldav4j moved to github which is now causing compiling error in uportal 

[ERROR] Failed to execute goal on project CalendarPortlet: Could not resolve dependencies for project org.jasig.portal.portlets-overlay:CalendarPortlet:war:4.0.16-SNAPSHOT: The following artifacts could not be resolved: org.osaf:caldav4j:jar:0.7, slide:jakarta-slide-webdavlib:jar:2.2pre1-httpclient-3.0: Failure to find org.osaf:caldav4j:jar:0.7 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]