### PR TITLE
CAP-202 : Build Dependency Failure caldav4j, slide

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <repository>
             <id>caldav4j.repo</id>
             <name>CalDav4J Repository</name>
-            <url>http://caldav4j.googlecode.com/svn/maven/</url>
+            <url>https://raw.githubusercontent.com/caldav4j/maven/master/repo/</url>
         </repository>
     </repositories>
     


### PR DESCRIPTION
The project caldav4j has moved to github. 
The old repository (google code ) does not exist anymore. The new repository is 
https://raw.githubusercontent.com/caldav4j/maven/master/repo/
For example here is the jar for caldav4j.
https://raw.githubusercontent.com/caldav4j/maven/master/repo/org/osaf/caldav4j/0.7/caldav4j-0.7.jar
I tried these changes with uPortal 4.0.16 and the the build is successful. Hope that does the trick.