### PR TITLE
CAP-202: Change repo URL from googlecode.com to jitpack.io for CalDav4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
         </repository>
         <repository>
             <id>caldav4j.repo</id>
-            <name>CalDav4J Repository</name>
-            <url>http://caldav4j.googlecode.com/svn/maven/</url>
+            <name>Only for CalDav4J Repository</name>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
     


### PR DESCRIPTION
https://issues.jasig.org/browse/CAP-202