### PR TITLE
CAP-218:  Drop the hibernate3-maven-plugin in favor of providing dire…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <joda-time.version>2.0</joda-time.version>
         <logbackVersion>1.1.2</logbackVersion>
         <resource-server.version>1.0.42</resource-server.version>
+        <servlet-api.version>2.5</servlet-api.version>
         <slf4jVersion>1.7.7</slf4jVersion>
         <spring.version>3.1.3.RELEASE</spring.version>
         <uportal-maven-plugin.version>1.0.0</uportal-maven-plugin.version>
@@ -196,7 +197,7 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
+                <version>${servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jcifs</groupId>
@@ -279,6 +280,12 @@
                         <artifactId>ehcache</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!-- Needed for schema reset;  version compatible with org.hibernate:hibernate:3.2.3.ga -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-tools</artifactId>
+                <version>3.2.3.GA</version>
             </dependency>
             <dependency>
                 <groupId>org.jasig.cas.client</groupId>
@@ -539,6 +546,10 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-tools</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jasig.portlet.courses</groupId>
@@ -858,35 +869,60 @@
                 <!-- extensions must be set to true to pick up the custom phases -->
                 <extensions>true</extensions>
             </plugin>
+            <!--
+             | Invoke this plugin as follows to drop and recreate the Calendar database tables...
+             |
+             |   > mvn db-init
+             +-->
             <plugin>
-                <!--
-                 | Invoke this plugin as follows to drop and recreate the Calendar database tables...
-                 |
-                 |   >mvn db-init
-                 +-->
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>hibernate3-maven-plugin</artifactId>
-                <version>2.2</version>
+                <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>schema-create</id>
                         <phase>db-init</phase>
                         <goals>
-                            <goal>hbm2ddl</goal>
+                            <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <tasks>
+                                <property name="runtime_classpath" refid="maven.runtime.classpath" />
+                                <property name="plugin_classpath" refid="maven.plugin.classpath" />
+
+                                <!--
+                                 | The following specifies failonerror=false because it will produce an exception like...
+                                 |
+                                 | java.sql.SQLSyntaxErrorException: a FOREIGN KEY constraint already exists on the set
+                                 |     of columns: FKF8F0C5957886B9ED in statement [alter table CALENDAR_CONFIGURATION
+                                 |     add constraint FKF8F0C5957886B9ED foreign key (CALENDAR_ID) references CALENDAR_STORE]
+                                 |
+                                 | Yet the schema will be created (as well as it ever was).
+                                 |
+                                 | The issue appears to stem from the fact that the CALENDAR_ID column is declared for
+                                 | both subclasses, but differently, in CalendarConfiguration.hbm.xml.
+                                 +-->
+
+                                <java failonerror="false" classname="org.jasig.portlet.calendar.util.SchemaCreator">
+                                    <sysproperty key="logback.configurationFile" value="command-line.logback.xml" />
+                                    <classpath>
+                                        <pathelement location="${project.build.directory}/${project.artifactId}/WEB-INF/context" />
+                                        <pathelement path="${runtime_classpath}" />
+                                        <pathelement path="${plugin_classpath}" />
+                                    </classpath>
+                                </java>
+                            </tasks>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <componentProperties>
-                        <propertyfile>target/${project.artifactId}-${project.version}/WEB-INF/classes/datasource.properties</propertyfile>
-                        <drop>true</drop>
-                    </componentProperties>
-                </configuration>
                 <dependencies>
                     <dependency>
-                        <groupId>${jdbc.groupId}</groupId>
-                        <artifactId>${jdbc.artifactId}</artifactId>
-                        <version>${jdbc.version}</version>
-                        <scope>compile</scope>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
+                        <version>${servlet-api.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>javax.portlet</groupId>
+                        <artifactId>portlet-api</artifactId>
+                        <version>2.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/main/java/org/jasig/portlet/calendar/util/SchemaCreator.java
+++ b/src/main/java/org/jasig/portlet/calendar/util/SchemaCreator.java
@@ -15,6 +15,7 @@
 
 package org.jasig.portlet.calendar.util;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -76,9 +77,9 @@ public class SchemaCreator implements ApplicationContextAware {
                 .getBean(SESSION_FACTORY_BEAN_NAME, LocalSessionFactoryBean.class);
         final DataSource dataSource = applicationContext.getBean(DATA_SOURCE_BEAN_NAME, DataSource.class);
 
-        try {
+        try (final Connection conn = dataSource.getConnection()) {
             final Configuration cfg = sessionFactoryBean.getConfiguration();
-            final SchemaExport schemaExport = new SchemaExport(cfg, dataSource.getConnection());
+            final SchemaExport schemaExport = new SchemaExport(cfg, conn);
             schemaExport.execute(true, true, false, false);
 
             final List<Exception> exceptions = schemaExport.getExceptions();

--- a/src/main/java/org/jasig/portlet/calendar/util/SchemaCreator.java
+++ b/src/main/java/org/jasig/portlet/calendar/util/SchemaCreator.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jasig.portlet.calendar.util;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.apache.log4j.Logger;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.jasig.portlet.calendar.spring.PortletApplicationContextLocator;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.orm.hibernate3.LocalSessionFactoryBean;
+
+/**
+ * This tool is responsible for creating the Calendar portlet database schema (and dropping
+ * it first, if necessary).  It leverages the org.hibernate:hibernate-tools library, but integrates
+ * with Calendar's Spring-managed ORM strategy and Calendar's configuration features (esp.
+ * encrypted properties).  It is invokable from the command line with '$ java', but designed to be
+ * integrated with build tools like Gradle.
+ */
+public class SchemaCreator implements ApplicationContextAware {
+
+    /*
+     * Prefixing a Spring factory bean with '&' gives you the factory itself, rather than the product.
+     * (https://stackoverflow.com/questions/2736100/how-can-i-get-the-hibernate-configuration-object-from-spring)
+     */
+    private static final String SESSION_FACTORY_BEAN_NAME = "&sessionFactory";
+
+    private static final String DATA_SOURCE_BEAN_NAME = "dataSource";
+
+    private ApplicationContext applicationContext;
+
+    private final Logger logger = Logger.getLogger(getClass());
+
+    public static void main(String[] args) {
+
+        // There will be an instance of this class in the ApplicationContent
+        ApplicationContext context =
+                PortletApplicationContextLocator.getApplicationContext(
+                        PortletApplicationContextLocator.DATABASE_CONTEXT_LOCATION);
+        final SchemaCreator schemaCreator = context.getBean("schemaCreator", SchemaCreator.class);
+        System.exit(schemaCreator.create());
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    private int create() {
+
+        /*
+         * We will need to provide a Configuration and a Connection;  both should be properly
+         * managed by the Spring ApplicationContext.
+         */
+
+        final LocalSessionFactoryBean sessionFactoryBean = applicationContext
+                .getBean(SESSION_FACTORY_BEAN_NAME, LocalSessionFactoryBean.class);
+        final DataSource dataSource = applicationContext.getBean(DATA_SOURCE_BEAN_NAME, DataSource.class);
+
+        try {
+            final Configuration cfg = sessionFactoryBean.getConfiguration();
+            final SchemaExport schemaExport = new SchemaExport(cfg, dataSource.getConnection());
+            schemaExport.execute(true, true, false, false);
+
+            final List<Exception> exceptions = schemaExport.getExceptions();
+            if (exceptions.size() != 0) {
+                logger.error("Schema Create Failed;  see below for details");
+                for (Exception e : exceptions) {
+                    logger.error("Exception from Hibernate Tools SchemaExport", e);
+                }
+                return 1;
+            }
+        } catch (SQLException sqle) {
+            logger.error("Failed to initialize & invoke the SchemaExport tool", sqle);
+            return 1;
+        }
+
+        return 0;
+
+    }
+
+}

--- a/src/main/resources/context/importExportContext.xml
+++ b/src/main/resources/context/importExportContext.xml
@@ -153,4 +153,7 @@
             </util:map>
         </property>
     </bean>
+
+    <!-- Used to [drop and] create the Announcements database schema from the command line -->
+    <bean id="schemaCreator" class="org.jasig.portlet.calendar.util.SchemaCreator" />
 </beans>

--- a/src/main/resources/context/importExportContext.xml
+++ b/src/main/resources/context/importExportContext.xml
@@ -154,6 +154,6 @@
         </property>
     </bean>
 
-    <!-- Used to [drop and] create the Announcements database schema from the command line -->
+    <!-- Used to [drop and] create the Calendar database schema from the command line -->
     <bean id="schemaCreator" class="org.jasig.portlet.calendar.util.SchemaCreator" />
 </beans>

--- a/src/main/resources/hibernate-mappings/CalendarConfiguration.hbm.xml
+++ b/src/main/resources/hibernate-mappings/CalendarConfiguration.hbm.xml
@@ -47,19 +47,19 @@
         <property name="displayed" type="boolean">
             <column name="DISPLAYED"/>
         </property>
-        
-        
+
+
         <!-- SUBCLASSES -->
         
         <!-- user-defined calendars and their configurations -->
         <subclass name="org.jasig.portlet.calendar.PredefinedCalendarConfiguration"
             discriminator-value="PD">
             
-            <many-to-one 
-                name="calendarDefinition" 
-                class="org.jasig.portlet.calendar.PredefinedCalendarDefinition" 
-                column="CALENDAR_ID" 
-                cascade="none" lazy="false"/> 
+            <many-to-one
+                name="calendarDefinition"
+                class="org.jasig.portlet.calendar.PredefinedCalendarDefinition"
+                column="CALENDAR_ID"
+                cascade="none" lazy="false"/>
             
             <!-- other user-specific preferences -->
             <map name="preferences" lazy="false" table="CALENDAR_PREFERENCE" cascade="all-delete-orphan"> 
@@ -75,11 +75,11 @@
         <subclass name="org.jasig.portlet.calendar.UserDefinedCalendarConfiguration"
             discriminator-value="UD">
             
-            <many-to-one 
-                name="calendarDefinition" 
+            <many-to-one
+                name="calendarDefinition"
                 class="org.jasig.portlet.calendar.UserDefinedCalendarDefinition"
                 column="CALENDAR_ID"
-                cascade="all" lazy="false"/> 
+                cascade="all" lazy="false"/>
             
         </subclass>
         


### PR DESCRIPTION
…ct support for database schema drop+create

https://issues.jasig.org/browse/CAP-218

The Calendar portlet implements a 'db-init' Maven goal that drops & re-creates the database schema.  This capability is integrated into the uP4 Maven build via uportal-portlets-overlay.

The current implementation is based on the hibernate3-maven-plugin.  This solution is problematic because (1) it's not well integrated into the rest of the app's features (so it's always been very brittle), and (2) it doesn't port well to the Gradle-based build in uP5.

We need to  replace it with something we provide directly that *is* a first-class part of the Spring app.