### PR TITLE
docs(readme): add maven badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # CalendarPortlet
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/CalendarPortlet/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/CalendarPortlet)
 [![Linux Build Status](https://travis-ci.org/Jasig/CalendarPortlet.svg?branch=master)](https://travis-ci.org/Jasig/CalendarPortlet)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/d8e32yt07o12mg23/branch/master?svg=true)](https://ci.appveyor.com/project/ChristianMurphy/calendarportlet/branch/master)
 


### PR DESCRIPTION
Give at-a-glance knowledge of:
* latest version number
* that this is available from maven central
* link to documentation on inclusion for maven, gradle, etc