### PR TITLE
Refactor: use upstream bootstrap and font awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This is a [Sponsored Portlet][] in the Apereo uPortal project.
 
 ## Configuration
 
-See also [documentation in the external wiki][CalendarPortlet in Confluence].  Earlier documentation may be found there, and is still relevant.  We are in the process of moving documentation here.
+See also [documentation in the external wiki][calendarportlet in confluence]. Earlier documentation may be found there, and is still relevant. We are in the process of moving documentation here.
 
 ### Using Encrypted Property Values
 
-You may optionally provide sensitive configuration items -- such as database passwords -- in encrypted format.  Use the [Jasypt CLI Tools](http://www.jasypt.org/cli.html) to encrypt the sensitive value, then include it in a `.properties` file like this:
+You may optionally provide sensitive configuration items -- such as database passwords -- in encrypted format. Use the [Jasypt CLI Tools](http://www.jasypt.org/cli.html) to encrypt the sensitive value, then include it in a `.properties` file like this:
 
 ```
 hibernate.connection.password=ENC(9ffpQXJi/EPih9o+Xshm5g==)
@@ -22,10 +22,23 @@ Specify the encryption key using the `UP_JASYPT_KEY` environment variable.
 
 ## Migrating to v2.3.0
 
-If using Exchange Web Services, the `configuration.properties` file has minor in order to support EWS Impersonation.  Several `*Context.xml` files are also updated in case you have overridden them in the uPortal overlays.
+If using Exchange Web Services, the `configuration.properties` file has minor in order to support EWS Impersonation. Several `*Context.xml` files are also updated in case you have overridden them in the uPortal overlays.
 
 `configuration.properties` changes:
-* `ntlm.domain` is renamed `exchangeWs.ntlm.domain`.  Also the meaning has changed a bit.  Refer to the comments in the file.
 
-[Sponsored Portlet]: https://wiki.jasig.org/display/PLT/Jasig+Sponsored+Portlets
-[CalendarPortlet in Confluence]: https://wiki.jasig.org/display/PLT/Calendar+Portlet
+* `ntlm.domain` is renamed `exchangeWs.ntlm.domain`. Also the meaning has changed a bit. Refer to the comments in the file.
+
+[sponsored portlet]: https://wiki.jasig.org/display/PLT/Jasig+Sponsored+Portlets
+[calendarportlet in confluence]: https://wiki.jasig.org/display/PLT/Calendar+Portlet
+
+## Dependencies
+
+These dependencies are expected to be loaded by overall uPortal:
+
+* [Font Awesome][] 4, last tested with [Font Awesome 4.7.0][]
+* [Bootstrap][] 3, last tested with [Bootstrap 3.3.7][]
+
+[font awesome]: http://fontawesome.io/
+[font awesome 4.7.0]: https://github.com/FortAwesome/Font-Awesome/releases/tag/v4.7.0
+[bootstrap]: https://getbootstrap.com
+[bootstrap 3.3.7]: https://getbootstrap.com/docs/3.3/

--- a/pom.xml
+++ b/pom.xml
@@ -851,7 +851,6 @@
                                 <include>rs/famfamfam/silk/1.3/tick.png</include>
                                 <include>rs/backbone/0.9.2/</include>
                                 <include>rs/underscore/1.3.3/</include>
-                                <include>rs/bootstrap-namespaced/3.1.1/css/</include>
                                 <include>rs/fontawesome/4.7.0/css/</include>
                                 <include>rs/jquery/1.11.0/</include>
                                 <include>rs/jquery-migrate/</include>

--- a/pom.xml
+++ b/pom.xml
@@ -851,7 +851,6 @@
                                 <include>rs/famfamfam/silk/1.3/tick.png</include>
                                 <include>rs/backbone/0.9.2/</include>
                                 <include>rs/underscore/1.3.3/</include>
-                                <include>rs/fontawesome/4.7.0/css/</include>
                                 <include>rs/jquery/1.11.0/</include>
                                 <include>rs/jquery-migrate/</include>
                                 <include>rs/jqueryui/1.10.3/</include>

--- a/src/main/webapp/WEB-INF/jsp/adminCalendars.jsp
+++ b/src/main/webapp/WEB-INF/jsp/adminCalendars.jsp
@@ -23,7 +23,7 @@
 <c:set var="n"><portlet:namespace/></c:set>
 <jsp:directive.include file="/WEB-INF/jsp/css.jsp"/>
 
-<div class="container-fluid bootstrap-styles upcal-adminview">
+<div class="container-fluid upcal-adminview">
     <div class="row">
         <div class="col-md-12">
             <!-- Add Calendar -->

--- a/src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp
@@ -30,7 +30,7 @@
 <jsp:directive.include file="/WEB-INF/jsp/scripts.jsp"/>
 
 <div id="${n}container" class="${n}upcal-miniview">
-    <div class="container-fluid bootstrap-styles upcal-events">
+    <div class="container-fluid upcal-events">
         <div class="upcal-event-view">
             <div class="row">
                 <div class="col-md-12">

--- a/src/main/webapp/WEB-INF/jsp/calendarWideView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarWideView.jsp
@@ -25,7 +25,7 @@
 
 <jsp:directive.include file="/WEB-INF/jsp/scripts.jsp"/>
 
-<div id="${n}container" class="container-fluid bootstrap-styles">
+<div id="${n}container" class="container-fluid">
     <c:if test="${ !model.guest && !(model.disablePreferences && (!sessionScope.isAdmin || model.disableAdministration)) }">
         <div class="row">
             <div class="col-md-12">

--- a/src/main/webapp/WEB-INF/jsp/createCalendarDefinition.jsp
+++ b/src/main/webapp/WEB-INF/jsp/createCalendarDefinition.jsp
@@ -23,7 +23,7 @@
 <c:set var="n"><portlet:namespace/></c:set>
 <jsp:directive.include file="/WEB-INF/jsp/css.jsp"/>
 
-<div class="container-fluid bootstrap-styles" role="section">
+<div class="container-fluid" role="section">
 
     <!-- Portlet Titlebar -->
     <div class="row" role="sectionhead">

--- a/src/main/webapp/WEB-INF/jsp/editCalendarDefinition.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editCalendarDefinition.jsp
@@ -57,7 +57,7 @@
     });
 </rs:compressJs></script>
 
-<div class="container-fluid bootstrap-styles" role="section">
+<div class="container-fluid" role="section">
     <div class="row">
         <div class="col-md-4">
             <h4 role="heading"><spring:message code="edit.calendar"/></h4>

--- a/src/main/webapp/WEB-INF/jsp/editCalendarUrl.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editCalendarUrl.jsp
@@ -23,7 +23,7 @@
 <c:set var="n"><portlet:namespace/></c:set>
 <jsp:directive.include file="/WEB-INF/jsp/css.jsp"/>
 
-<div class="upcal-edit-urlview container-fluid bootstrap-styles">
+<div class="upcal-edit-urlview container-fluid">
 
     <h4><spring:message code="edit.calendar"/></h4>
 

--- a/src/main/webapp/WEB-INF/jsp/editCalendars.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editCalendars.jsp
@@ -26,7 +26,7 @@
 
 <portlet:renderURL portletMode="view" var="returnUrl"/>
 
-<div class="container-fluid bootstrap-styles">
+<div class="container-fluid">
 
     <div class="row">
         <div class="col-md-4">

--- a/src/main/webapp/skin-shared.xml
+++ b/src/main/webapp/skin-shared.xml
@@ -21,9 +21,6 @@
 <resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
 
-    <css included="aggregated" resource="true">/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
-    <css included="plain" resource="true">/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
-
     <js included="plain" resource="true">/rs/backbone/0.9.2/backbone-0.9.2.js</js>
     <js included="aggregated" resource="true">/rs/backbone/0.9.2/backbone-0.9.2.min.js</js>
 

--- a/src/main/webapp/skin-shared.xml
+++ b/src/main/webapp/skin-shared.xml
@@ -21,9 +21,6 @@
 <resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
 
-    <css included="aggregated" resource="true">/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css</css>
-    <css included="plain" resource="true">/rs/bootstrap-namespaced/3.1.1/css/bootstrap.css</css>
-
     <css included="aggregated" resource="true">/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
     <css included="plain" resource="true">/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
 

--- a/src/main/webapp/skin.xml
+++ b/src/main/webapp/skin.xml
@@ -21,9 +21,6 @@
 <resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
 
-    <css included="aggregated" resource="true">/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
-    <css included="plain" resource="true">/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
-
     <css>css/calendar.css</css>
 
     <js included="plain" resource="true">/rs/jquery/1.11.0/jquery-1.11.0.js</js>

--- a/src/main/webapp/skin.xml
+++ b/src/main/webapp/skin.xml
@@ -21,9 +21,6 @@
 <resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
 
-    <css included="aggregated" resource="true">/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css</css>
-    <css included="plain" resource="true">/rs/bootstrap-namespaced/3.1.1/css/bootstrap.css</css>
-
     <css included="aggregated" resource="true">/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
     <css included="plain" resource="true">/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
 


### PR DESCRIPTION
There have been conflicts occuring between customized upstream Bootstrap and this scoped Bootstrap.
The issue stems from the upstream bootstrap being customized, and having colors changes that should be applied to ensure WCAG 2.0 AA contrast requirements.
However those styles are being overridden by the scoped stylesheet.
This removes the conflict, by removing the scoped css and leveraging the stylesheet provided by uPortal.