### PR TITLE
CAP-227:  createCalendarDefinition.jsp uses a renderURL in a POST, wh…

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/createCalendarDefinition.jsp
+++ b/src/main/webapp/WEB-INF/jsp/createCalendarDefinition.jsp
@@ -41,8 +41,9 @@
     </div>
     <div class="row" role="main">
         <div class="col-md-6 col-md-offset-2">
-            <portlet:renderURL escapeXml='false' var="postUrl"><portlet:param name="action" value="createCalendarDefinition2"/></portlet:renderURL>
-            <form:form name="calendar" commandName="calendarDefinitionForm" action="${postUrl}" class="form-horizontal" role="form">
+            <!-- It's unusual to use a renderURL here, but there's no server-side behavior that violates the principals of Render vs. Action. -->
+            <portlet:renderURL escapeXml='false' var="formRenderUrl"><portlet:param name="action" value="createCalendarDefinition2"/></portlet:renderURL>
+            <form:form name="calendar" commandName="calendarDefinitionForm" action="${formRenderUrl}" class="form-horizontal" role="form" method="GET">
                 <div class="row">
                     <div class="col-md-12">
                         <spring:hasBindErrors name="calendarDefinitionForm">


### PR DESCRIPTION
…ich results in '403 Forbidden'

https://issues.jasig.org/browse/CAP-227

uPortal 5 adds CSRF protection through tokens managed by Spring Security.

This protection is automatic for portlets (no changes required), provided that portlets always use an actionURL for any POST request.  (That was always a best practice.)

createCalendarDefinition.jsp has a <form> that violates this pattern:  it uses a renderURL in a <form> with method=post.

We should change the method to GET or change the URL to an actionURL.