### PR TITLE
fix(84): Change fallback for codehaus from defunct Jasig repo to mule…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,18 @@
 
     <repositories>
         <repository>
-            <id>jasig-3rd-party</id>
-            <name>Jasig 3rd Party Repository</name>
+            <id>Mulesoft</id>
+            <name>Mulesoft Repository</name>
+            <!-- mirror of most Codehaus artifacts -->
             <url>https://repository.mulesoft.org/nexus/content/repositories/public</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+            <id>Antricore</id>
+            <name>Atricore Repository</name>
+            <!-- mirror of even more Codehaus artifacts -->
+            <url>http://repository.atricore.org/m2-release-repository/</url>
             <releases><enabled>true</enabled></releases>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <repository>
             <id>jasig-3rd-party</id>
             <name>Jasig 3rd Party Repository</name>
-            <url>http://developer.jasig.org/repo/content/repositories/3rd-party</url>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public</url>
             <releases><enabled>true</enabled></releases>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>


### PR DESCRIPTION
…soft.

Fixes #84.