### PR TITLE
refactor: replace NotThreadSafe with Contract annotation

### DIFF
--- a/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWebServiceCallBack.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWebServiceCallBack.java
@@ -25,7 +25,7 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.annotation.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ws.WebServiceMessage;
@@ -35,7 +35,7 @@ import org.springframework.ws.soap.SoapMessage;
 import org.springframework.ws.soap.client.core.SoapActionCallback;
 import org.springframework.xml.transform.StringSource;
 
-@NotThreadSafe
+@Contract()
 public class ExchangeWebServiceCallBack implements WebServiceMessageCallback {
   private final Logger log = LoggerFactory.getLogger(getClass());
   private static final String impersonationFirstPart =


### PR DESCRIPTION
Removed due to https://issues.apache.org/jira/browse/HTTPCLIENT-1743
`Contract` appears to be the replacement class