### PR TITLE
chore: bump parent to v49 and inherit license-plugin defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>48</version>
+        <version>49</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -823,29 +823,22 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
-                    <aggregate>true</aggregate>
+                    <!--
+                      | Parent v49 provides the standard excludes (LICENSE,
+                      | NOTICE, NOTICE.template, target/**, pom.xml.*,
+                      | release.properties, bin/**, .idea/**, overlays/**,
+                      | .gitignore, **/src/main/webapp/rs/**) and standard
+                      | mappings (channel/less/tag/xjb/etc). Local block
+                      | keeps only the CalendarPortlet-specific excludes
+                      | and the <portlet> mapping.
+                    +-->
                     <excludes>
-                        <exclude>.gitignore</exclude>
-                        <exclude>target/**</exclude>
-                        <exclude>pom.xml.*</exclude>
-                        <exclude>release.properties</exclude>
-                        <exclude>LICENSE</exclude>
-                        <exclude>NOTICE</exclude>
-                        <exclude>NOTICE.template</exclude>
                         <exclude>src/main/resources/com/microsoft/exchange/Services.wsdl</exclude>
                         <exclude>src/test/resources/sampleEvents.ics</exclude>
-                        <exclude>**/src/main/webapp/rs/**</exclude>
-                        <exclude>bin/**</exclude>
-                        <exclude>.idea/**</exclude> <!-- Exclude intelliJ files -->
-                        <exclude>overlays/**</exclude> <!-- Exclude intelliJ files -->
                         <exclude>3rd-party/**</exclude>
                     </excludes>
                     <mapping>
-                        <channel>XML_STYLE</channel>
-                        <less>SLASHSTAR_STYLE</less>
                         <portlet>XML_STYLE</portlet>
-                        <tag>DYNASCRIPT_STYLE</tag>
-                        <xjb>XML_STYLE</xjb>
                     </mapping>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary

Bumps to parent v49 and shrinks the local `license-maven-plugin` block to only the CalendarPortlet-specific bits.

Part of the post-v49 fleet sweep (see #105 / #347 / #65 / #142 across the other repos).

## Changes

`pom.xml`:
- Parent `48` → `49`.
- Drop the redundant `<aggregate>true</aggregate>` (parent provides).
- Shrink `<excludes>` from 14 entries to 3 — keep only the genuinely CalendarPortlet-specific ones (`src/main/resources/com/microsoft/exchange/Services.wsdl`, `src/test/resources/sampleEvents.ics`, `3rd-party/**`). Drop `LICENSE`, `NOTICE`, `NOTICE.template`, `target/**`, `pom.xml.*`, `release.properties`, `bin/**`, `.idea/**`, `overlays/**`, `.gitignore`, `**/src/main/webapp/rs/**` — all in parent v49.
- Shrink `<mapping>` from 5 entries to 1 — keep only `<portlet>XML_STYLE</portlet>` (parent doesn't define one). Drop `channel`, `less`, `tag`, `xjb` — parent has all four.


## Out of scope

`maven-release-plugin` is at 3.3.1 locally vs parent's 3.1.1 — drift ahead, not behind. Left for a separate fleet-version-alignment conversation.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn license:check` — green
- [ ] CI on Java 11 matrix
