### PR TITLE
chore: bump parent v50 -> v51 and migrate commons-lang -> commons-lang3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -21,14 +21,14 @@ This project includes:
   The famfamfam Silk Icons under the Creative Commons Attribution 3.0 License
     http://www.famfamfam.com/lab/icons/silk/
 
-  %systemBundle under Eclipse Public License - v 1.0
-  ant under The Apache Software License, Version 2.0
   ant-launcher under Apache License, Version 2.0
   AntLR under BSD License
   AOP alliance under Public Domain
+  Apache Ant Core under The Apache Software License, Version 2.0
   Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons IO under Apache-2.0
+  Apache Commons Lang under Apache-2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
   Apache Pluto Portlet Tag Library under The Apache Software License, Version 2.0
@@ -42,43 +42,47 @@ This project includes:
   Batik CSS engine under The Apache Software License, Version 2.0
   Batik external code under The Apache Software License, Version 2.0
   Batik utility library under The Apache Software License, Version 2.0
+  Bouncy Castle ASN.1 Extension and Utility APIs under Bouncy Castle Licence
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs under Bouncy Castle Licence
   Bouncy Castle Provider under Bouncy Castle Licence
+  Byte Buddy (without dependencies) under Apache License, Version 2.0
+  Byte Buddy agent under Apache License, Version 2.0
   CalDav4j under Apache License, Version 2.0
   Calendar Portlet under Apache License Version 2.0
   castor under Apache License, Version 2.0
   Cernunnos - Core under Apache 2
+  Checker Qual under The MIT License
   Code Generation Library under ASF 2.0
-  Commands under Eclipse Public License - v 1.0
-  Common Eclipse Runtime under Eclipse Public License - v 1.0
   Commons DBCP under The Apache Software License, Version 2.0
   Commons FileUpload under The Apache Software License, Version 2.0
   Commons JEXL under The Apache Software License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
   Commons Pool under The Apache Software License, Version 2.0
   commons-beanutils under Apache License, Version 2.0
-  Core Runtime under Eclipse Public License - v 1.0
+  commons-collections under Apache License, Version 2.0
   CoursePortlet - API under Apache License Version 2.0
   CoursePortlet - Data Access Objects for SIS/LMS integration under Apache License Version 2.0
   Cryptacular Library under Apache 2 or GNU Lesser General Public License
   cvsclient under Sun Public License
   dom4j under BSD License
-  Eclipse Content Mechanism under Eclipse Public License - v 1.0
-  Eclipse Jobs Mechanism under Eclipse Public License - v 1.0
-  Eclipse Preferences Mechanism under Eclipse Public License - v 1.0
   ehcache under The Apache Software License, Version 2.0
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
-  Equinox Application Container under Eclipse Public License - v 1.0
+  Error Prone shaded javac under GNU General Public License, version 2, with the Classpath Exception
+  error-prone annotations under Apache 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   Extended StAX API under Eclipse Distribution License - v 1.0
-  Extension Registry Support under Eclipse Public License - v 1.0
   ezmorph under The Apache Software License, Version 2.0
   fastinfoset under Apache License, Version 2.0 or Eclipse Distribution License - v 1.0
+  FindBugs-jsr305 under The Apache Software License, Version 2.0
   freemarker under BSD-style license
   GlassFish High Availability APIs and SPI under EPL 2.0 or GPL2 w/ CPE
-  gmbal under EDL 1.0
+  GMBAL (API only) under EDL 1.0
+  Google Java Format under The Apache Software License, Version 2.0
   Groovy under Apache License, Version 2.0
-  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
+  Guava ListenableFuture only under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under Apache License, Version 2.0
   Hamcrest Core under New BSD License
   Hibernate Commons Annotations under GNU LESSER GENERAL PUBLIC LICENSE
   Hibernate Core under GNU Lesser General Public License
@@ -87,13 +91,16 @@ This project includes:
   HttpClient under Apache License
   HyperSQL Database under HSQLDB License, a BSD open source license
   iCal4j under iCal4j - License
-  ICU4J under Unicode/ICU License
+  icu4j under MIT License
+  istack common utility code runtime under CDDL 1.1 or GPL2 w/ CPE
+  J2ObjC Annotations under Apache License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
   Jakarta Activation under EDL 1.0
   Jakarta Activation API jar under EDL 1.0
   Jakarta Annotations API under EPL 2.0 or GPL2 w/ CPE
+  Jakarta Mail API under EPL 2.0 or GPL2 w/ CPE or EDL 1.0
   Jakarta SOAP Implementation under Eclipse Distribution License - v 1.0
   Jakarta SOAP with Attachments API under Eclipse Distribution License - v 1.0
   Jakarta Web Services Metadata API under Eclipse Distribution License - v 1.0
@@ -112,12 +119,14 @@ This project includes:
   JavaMail API under Sun Binary Code License
   Javassist under LGPL 2.1
   javax.script:groovy-engine under BSD License
+  javax.transaction API under CDDL + GPLv2 with classpath exception
   JAX-WS RI Runtime (jaxws-rt) under Eclipse Distribution License - v 1.0
+  JAXB Core under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   jaxen under Apache style license
   jCIFS under GNU Lesser General Public License, version 2.1
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
+  JCL 1.2 implemented over SLF4J under Apache-2.0
   jdom under Apache style license
   JLine under BSD
   Joda-Time under Apache License, Version 2.0
@@ -125,18 +134,17 @@ This project includes:
   json-lib under Apache License, Version 2.0
   JSR-250 Common Annotations for the JavaTM Platform under COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
   jstl under Commons Development and Distribution License, Version 1.0
-  JTidy under Java HTML Tidy License
-  JUL to SLF4J bridge under MIT License
+  JUL to SLF4J bridge under MIT
   JUnit under Eclipse Public License 1.0
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Log4j Implemented Over SLF4J under Apache-2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   management-api under EDL 1.0
   MIME streaming extension under Eclipse Distribution License - v 1.0
-  Mockito under The MIT License
+  mockito-core under MIT
   MXParser under Indiana University Extreme! Lab Software License
   Neko HTML under The Apache Software License, Version 2.0
-  Objenesis under Apache 2
+  Objenesis under Apache License, Version 2.0
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
   OpenSAML :: Core under The Apache Software License, Version 2.0
   OpenSAML :: Profile API under The Apache Software License, Version 2.0
@@ -153,10 +161,7 @@ This project includes:
   OpenSAML :: XML Security Implementation under The Apache Software License, Version 2.0
   OpenSAML-J under Apache 2
   OpenWS under Apache 2
-  org.apache.tools.ant under Apache License, Version 2.0
   OWASP AntiSamy under BSD License
-  PFL Basic under EDL 1.0
-  PFL TF under EDL 1.0
   policy under Eclipse Distribution License - v 1.0
   Portlet Form Resources under Apache License Version 2.0
   Resource Server API under Apache License Version 2.0
@@ -164,8 +169,8 @@ This project includes:
   Resource Server Core under Apache License Version 2.0
   Resource Server Utilities under Apache License Version 2.0
   ROME, RSS and atOM utilitiEs for Java under Apache License, Version 2.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
-  SLF4J API Module under MIT License
+  serializer under Apache License, Version 2.0
+  SLF4J API Module under MIT
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
   Spring Context under Apache License, Version 2.0
@@ -175,7 +180,7 @@ This project includes:
   Spring JDBC under Apache License, Version 2.0
   Spring LDAP Core under The Apache Software License, Version 2.0
   Spring Object/Relational Mapping under Apache License, Version 2.0
-  Spring Object/XML Marshalling under The Apache Software License, Version 2.0
+  Spring Object/XML Marshalling under Apache License, Version 2.0
   Spring TestContext Framework under Apache License, Version 2.0
   Spring Transaction under Apache License, Version 2.0
   Spring Web under Apache License, Version 2.0
@@ -186,15 +191,13 @@ This project includes:
   spring-ws-security under Apache License, Version 2.0
   spring-xml under Apache License, Version 2.0
   standard under Apache License, Version 2.0
-  Stax2 API under The BSD License
+  Stax2 API under The BSD 2-Clause License
   Streaming API for XML under Sun Binary Code License
-  Text under Eclipse Public License - v 1.0
-  Tycho org.eclipse.jdt.core dependency (Incubation) under Eclipse Public License
+  TXW2 Runtime under CDDL+GPL License
   uPortal under The Apache License, Version 2.0
   uPortal Search API under Apache License Version 2.0
-  Woodstox under The Apache License, Version 2.0
+  Woodstox under The Apache Software License, Version 2.0
   xalan under Apache License, Version 2.0
-  Xalan Java Serializer under The Apache Software License, Version 2.0
   Xerces2-j under The Apache Software License, Version 2.0
   XML Commons External Components XML APIs under The Apache Software License, Version 2.0
   XML Commons External Components XML APIs Extensions under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>50</version>
+        <version>51</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -196,8 +196,8 @@
             <version>2.14.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>${jdbc.groupId}</groupId>

--- a/src/main/java/org/jasig/portlet/calendar/CalendarConfigurationByNameComparator.java
+++ b/src/main/java/org/jasig/portlet/calendar/CalendarConfigurationByNameComparator.java
@@ -19,7 +19,7 @@
 package org.jasig.portlet.calendar;
 
 import java.util.Comparator;
-import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 
 /**
  * @author Jen Bourey, jbourey@unicon.net

--- a/src/main/java/org/jasig/portlet/calendar/adapter/CoursesCalendarAdapter.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/CoursesCalendarAdapter.java
@@ -45,7 +45,7 @@ import net.fortuna.ical4j.model.property.Version;
 import net.fortuna.ical4j.util.UidGenerator;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portlet.calendar.CalendarConfiguration;

--- a/src/main/java/org/jasig/portlet/calendar/adapter/ExchangeCalendarAdapter.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/ExchangeCalendarAdapter.java
@@ -51,7 +51,7 @@ import net.fortuna.ical4j.model.property.Summary;
 import net.fortuna.ical4j.model.property.Uid;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.calendar.CalendarConfiguration;
 import org.jasig.portlet.calendar.adapter.exchange.ExchangeWebServiceCallBack;
 import org.jasig.portlet.calendar.adapter.exchange.IExchangeCredentialsInitializationService;

--- a/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeCredentialsInitializationService.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeCredentialsInitializationService.java
@@ -21,7 +21,7 @@ package org.jasig.portlet.calendar.adapter.exchange;
 import java.util.Map;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;

--- a/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWebServiceCallBack.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/exchange/ExchangeWebServiceCallBack.java
@@ -24,7 +24,7 @@ import javax.xml.namespace.QName;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.annotation.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/jasig/portlet/calendar/credentials/RequestAttributeCredentialsExtractorImpl.java
+++ b/src/main/java/org/jasig/portlet/calendar/credentials/RequestAttributeCredentialsExtractorImpl.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import javax.portlet.PortletRequest;
 import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/org/jasig/portlet/calendar/mvc/CalendarDisplayEvent.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/CalendarDisplayEvent.java
@@ -19,9 +19,9 @@
 package org.jasig.portlet.calendar.mvc;
 
 import net.fortuna.ical4j.model.component.VEvent;
-import org.apache.commons.lang.builder.CompareToBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.format.DateTimeFormatter;

--- a/src/main/java/org/jasig/portlet/calendar/mvc/controller/CalendarController.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/controller/CalendarController.java
@@ -28,7 +28,7 @@ import javax.portlet.PortletSession;
 import javax.portlet.RenderRequest;
 import javax.portlet.WindowState;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portlet.calendar.CalendarConfiguration;

--- a/src/main/java/org/jasig/portlet/calendar/mvc/controller/SearchContentController.java
+++ b/src/main/java/org/jasig/portlet/calendar/mvc/controller/SearchContentController.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import javax.portlet.Event;
 import javax.portlet.EventRequest;
 import javax.portlet.EventResponse;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portal.search.PortletUrl;
 import org.jasig.portal.search.PortletUrlParameter;
 import org.jasig.portal.search.SearchConstants;

--- a/src/main/java/org/jasig/portlet/calendar/spring/DoubleCheckedCreator.java
+++ b/src/main/java/org/jasig/portlet/calendar/spring/DoubleCheckedCreator.java
@@ -21,7 +21,7 @@ package org.jasig.portlet.calendar.spring;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/org/jasig/portlet/calendar/spring/SingletonDoubleCheckedCreator.java
+++ b/src/main/java/org/jasig/portlet/calendar/spring/SingletonDoubleCheckedCreator.java
@@ -19,8 +19,8 @@
 package org.jasig.portlet.calendar.spring;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Provides a DoubleCheckedCreator impl that tracks the singleton instance internally

--- a/src/main/java/org/jasig/portlet/calendar/util/AllDayUtil.java
+++ b/src/main/java/org/jasig/portlet/calendar/util/AllDayUtil.java
@@ -21,7 +21,7 @@ package org.jasig.portlet.calendar.util;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.commons.lang.time.FastDateFormat;
+import org.apache.commons.lang3.time.FastDateFormat;
 
 /**
  * AllDayUtil determines whether a particular event should be classified as an "all-day" event in


### PR DESCRIPTION
Release-prep PR for CalendarPortlet 2.7.1, aligning with the fleet-wide v51 + lang3 wave.

## Summary

Two commits, each independently buildable:

1. **Parent v50 -> v51 + commons-lang -> commons-lang3**: parent v51 dropped legacy `commons-lang` from dM and added `commons-lang3` + `commons-text`. Source migration (12 files, mostly the Exchange adapter package) is the standard package rename — `org.apache.commons.lang.*` to `org.apache.commons.lang3.*`. lang3 is API-compatible for the StringUtils, Validate, and builder.* classes used here. Closes CVE-2025-48924 (commons-lang 2.x DoS in `StringUtils.escapeJava`).
2. **Regenerate NOTICE**: aligns with the post-v51 dep tree — picks up commons-lang3, commons-compress, byte-buddy, checker-qual; drops several Eclipse Equinox/Tycho shells that were transitive but unused at runtime; rolls Logback EPL v1 -> v2 from parent v51.

The earlier v49 -> v50 bump (CVE-2023-37460 plexus-archiver) already shipped via #394 and is the merge base here.

## Test plan

- [x] `mvn -B clean install` passes locally on Java 11
- [x] `mvn notice:check` passes
- [x] `mvn license:check` passes
- [ ] CI green
- [ ] Post-merge: `mvn release:clean release:prepare release:perform` for 2.7.1