### PR TITLE
fix: align jackson + revert ERB template option from 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
         <hibernateTools.version>3.6.2.Final</hibernateTools.version>
         <icu4j.version>72.1</icu4j.version>
         <jackson.version>2.18.6</jackson.version>
-        <jackson-databind.version>2.13.4.2</jackson-databind.version>
         <jaxb2basicsVersion>0.12.0</jaxb2basicsVersion>
         <joda-time.version>2.14.2</joda-time.version>
         <logbackVersion>1.3.12</logbackVersion>
@@ -266,9 +265,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <!-- Local override: parent BOM provides 2.18.6 but this portlet's
-                 Hibernate 3.6 / Spring 4.3 stack is validated against 2.13.4.2. -->
-            <version>2.21.3</version>
         </dependency>
         <dependency>
             <groupId>org.jasig.cas.client</groupId>

--- a/src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp
@@ -221,12 +221,12 @@ ${n}.jQuery(function() {
 
     var ListView = upcal.EventListView.extend({
         el: "#${n}container .upcal-event-view",
-        template: _.template($("#event-list-template").html(), {evaluate: /<%([^%>]+)%>/g, interpolate: /<%=([^%>]+)%>/g, escape: /<%-([^%>]+)%>/g})
+        template: _.template($("#event-list-template").html())
     });
 
     var DetailView = upcal.EventDetailView.extend({
         el: "#${n}container .upcal-event-details",
-        template: _.template($("#event-detail-template").html(), {evaluate: /<%([^%>]+)%>/g, interpolate: /<%=([^%>]+)%>/g, escape: /<%-([^%>]+)%>/g})
+        template: _.template($("#event-detail-template").html())
     });
 
     var view = new upcal.CalendarView({

--- a/src/main/webapp/WEB-INF/jsp/calendarWideView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarWideView.jsp
@@ -224,12 +224,12 @@ ${n}.jQuery(function() {
 
     var ListView = upcal.EventListView.extend({
         el: "#${n}container .upcal-event-view",
-        template: _.template($("#event-list-template").html(), {evaluate: /<%([^%>]+)%>/g, interpolate: /<%=([^%>]+)%>/g, escape: /<%-([^%>]+)%>/g})
+        template: _.template($("#event-list-template").html())
     });
 
     var DetailView = upcal.EventDetailView.extend({
         el: "#${n}container .upcal-event-details",
-        template: _.template($("#event-detail-template").html(), {evaluate: /<%([^%>]+)%>/g, interpolate: /<%=([^%>]+)%>/g, escape: /<%-([^%>]+)%>/g})
+        template: _.template($("#event-detail-template").html())
     });
 
     var view = new upcal.CalendarView({


### PR DESCRIPTION
Two regressions in 2.7.1 surfaced during uPortal-start smoke testing. Bundling them in one patch since they're both in the same release stream.

## Problem 1 — jackson version mismatch

2.7.1 ended up with \`jackson-databind\` 2.21.3 hardcoded as a local override while \`jackson-annotations\` and \`jackson-core\` inherited 2.18.6 from \`uportal-portlet-parent\` v51's BOM. \`databind\` 2.21+ references \`JsonSerializeAs\` (added to \`jackson-annotations\` 2.19+), so on the runtime classpath the bean factory blows up at static init of \`JacksonAnnotationIntrospector\`:

\`\`\`
NoClassDefFoundError: com/fasterxml/jackson/annotation/JsonSerializeAs
    at com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector.<clinit>
\`\`\`

…which manifests as *"Unable to successfully invoke portlet"* for the calendar portlet in uPortal. \`jackson-annotations\` 2.21.3 isn't published on Central (only \`-databind\` patches into 2.21.x; \`-annotations\` stops at 2.21 with no patch line), so bumping to match was not an option.

There are also stale comments in the pom suggesting the dep was *"validated against 2.13.4.2"* while the hardcoded version was actually 2.21.3 — that mismatch is now removed.

## Problem 2 — JSP compile error from explicit underscore.js ERB delimiter regex

2.7.1's frontend refresh (commit \`3afb599\`, *"ERB delimiters are now scoped to each \`_.template()\` call"*) added explicit \`evaluate\`, \`interpolate\`, and \`escape\` regex options to four \`_.template(...)\` calls in the narrow and wide JSP views. The regex literals contain \`<%\` directly in JSP source. JSP scanner sees \`<%\` as a scriptlet open and the JSP fails to compile:

\`\`\`
JasperException: Unable to compile class for JSP:
An error occurred at line: [224] in the jsp file: [/WEB-INF/jsp/calendarNarrowView.jsp]
Syntax error on token "[", invalid Expression
\`\`\`

Calendar rendering is dead while this ships.

Underscore's *defaults* are exactly the same regex shape the override spelled out (modulo non-greedy \`[\\s\\S]+?\` vs negated-class \`[^%>]+\`, functionally equivalent for the templates here), and nothing in this codebase mutates \`_.templateSettings\`, so there's no real collision the override defends against.

## Changes

- **pom.xml**: drop the unused \`<jackson-databind.version>\` property and the hardcoded \`<version>2.21.3</version>\` on the \`jackson-databind\` dep, plus the now-stale *"validated against 2.13.4.2"* comment. Lets parent v51's \`jackson-bom\` 2.18.6 provide it transitively, matching \`jackson-annotations\` and \`jackson-core\`.
- **src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp** and **calendarWideView.jsp**: revert the four \`_.template(html, {evaluate:..., interpolate:..., escape:...})\` calls back to \`_.template(html)\` (matches 2.7.0). Underscore's defaults are identical and JSP no longer trips on \`<%\` in source.

## Test plan

- [x] \`mvn -B clean install notice:check license:check\` passes locally on Java 11
- [x] Built locally as \`2.7.2-SNAPSHOT\`, deployed into uPortal-start, restarted Tomcat — \`JsonSerializeAs\` and \`JasperException\` errors both gone from the calendar log; no SEVERE context startup failures
- [x] Verified the built war bundles \`jackson-databind-2.18.6.jar\`, \`jackson-annotations-2.18.6.jar\`, \`jackson-core-2.18.6.jar\` (consistent)
- [ ] CI green
- [ ] Post-merge: \`mvn release:clean release:prepare release:perform\` for 2.7.2