### PR TITLE
fix(view): pass standard Underscore templateSettings on every compile

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarNarrowView.jsp
@@ -221,12 +221,12 @@ ${n}.jQuery(function() {
 
     var ListView = upcal.EventListView.extend({
         el: "#${n}container .upcal-event-view",
-        template: _.template($("#event-list-template").html())
+        template: _.template($("#event-list-template").html(), ${n}.upcalTemplateSettings)
     });
 
     var DetailView = upcal.EventDetailView.extend({
         el: "#${n}container .upcal-event-details",
-        template: _.template($("#event-detail-template").html())
+        template: _.template($("#event-detail-template").html(), ${n}.upcalTemplateSettings)
     });
 
     var view = new upcal.CalendarView({

--- a/src/main/webapp/WEB-INF/jsp/calendarWideView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendarWideView.jsp
@@ -224,12 +224,12 @@ ${n}.jQuery(function() {
 
     var ListView = upcal.EventListView.extend({
         el: "#${n}container .upcal-event-view",
-        template: _.template($("#event-list-template").html())
+        template: _.template($("#event-list-template").html(), ${n}.upcalTemplateSettings)
     });
 
     var DetailView = upcal.EventDetailView.extend({
         el: "#${n}container .upcal-event-details",
-        template: _.template($("#event-detail-template").html())
+        template: _.template($("#event-detail-template").html(), ${n}.upcalTemplateSettings)
     });
 
     var view = new upcal.CalendarView({

--- a/src/main/webapp/WEB-INF/jsp/editCalendarDefinition.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editCalendarDefinition.jsp
@@ -35,8 +35,9 @@
                 this.render();
             },
             render: function( ){
-                // Compile the template using underscore
-                var template = _.template( $("#${n}roleParamTemplate").html(), {} );
+                // Compile the template using underscore. Pass our template
+                // settings explicitly — see scripts.jsp for why.
+                var template = _.template( $("#${n}roleParamTemplate").html(), ${n}.upcalTemplateSettings );
                 // Load the compiled HTML into the Backbone "el"
                 this.$el.html( template );
             }

--- a/src/main/webapp/WEB-INF/jsp/scripts.jsp
+++ b/src/main/webapp/WEB-INF/jsp/scripts.jsp
@@ -25,6 +25,19 @@
     ${n}.jQuery = up.jQuery;
     ${n}._ = up._;
     ${n}.Backbone = up.Backbone;
+    // uPortal's respondr.xsl resets the shared up._.templateSettings to
+    // Mustache-style sigils. Our Underscore templates use the standard
+    // sigils, so each _.template() call must pass these settings
+    // explicitly to avoid the raw template source leaking into the
+    // rendered output. The view JSPs already use the ${"<%"}/${"%>"}
+    // EL trick to emit literal Underscore sigils into the rendered HTML;
+    // we use the same trick here so the regex literals survive JSP's
+    // own scriptlet parser.
+    ${n}.upcalTemplateSettings = {
+        interpolate: /${"<%"}=([\s\S]+?)${"%>"}/g,
+        evaluate:    /${"<%"}([\s\S]+?)${"%>"}/g,
+        escape:      /${"<%"}-([\s\S]+?)${"%>"}/g
+    };
     if (!upcal.initialized) upcal.init(${n}.jQuery, ${n}._, ${n}.Backbone);
     ${n}.upcal = upcal;
 </script>


### PR DESCRIPTION
## Problem

Every Underscore template in CalendarPortlet (event list, event detail, admin role-param row) currently renders its raw source into the portlet body instead of being interpolated. The events column shows literal text like:

    <% if (_(days).size() === 0) { %>
        ...
        <%= day.displayName %>
        ...
        <%= event.attributes.summary %>

…where the actual events should appear. Screenshot before:

```
| ... small calendar grid ...  | <% if (_(days)... %>... raw template text ... |
```

## Root cause

uPortal's `respondr.xsl` (`uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl`, ~line 274) does:

```js
up._ = _.noConflict();
up._.templateSettings = {
    interpolate: /{{=(.+?)}}/g,
    evaluate:    /{{(.+?)}}/g,
    escape:      /{{-([\s\S]+?)}}/g
};
```

`scripts.jsp` aliases that same instance via `${n}._ = up._`, so every `_.template(...)` call in this portlet inherits the Mustache delimiters at runtime. The portlet's templates use the standard `<% %>` / `<%= %>` sigils, which no longer match anything in the (Mustache) regex. Underscore returns the source unchanged, the rendered HTML is the template, and the user sees the raw Underscore syntax in the events column.

The Mustache override in uPortal is intentional and shipping: Marketplace and other portlets rely on it. Mutating `up._.templateSettings` back from this portlet would break those.

## Fix

Set a per-portlet-namespace `${n}.upcalTemplateSettings` object once in `scripts.jsp` and pass it to every `_.template(...)` call as the second argument. Underscore 1.8.3's `_.template(text, settings)` does `_.defaults({}, settings, _.templateSettings)`, so the explicit settings win without touching the shared global.

The regex literals in `scripts.jsp` are emitted via the `${\"<%\"}...${\"%>\"}` EL trick — the same trick the view JSPs already use to write literal Underscore sigils into rendered HTML templates — so JSP's own scriptlet parser doesn't swallow the regex while compiling the page.

## Files changed

- `scripts.jsp` — define `${n}.upcalTemplateSettings`.
- `calendarWideView.jsp` — pass settings to both `_.template(...)` calls (event list, event detail).
- `calendarNarrowView.jsp` — same two calls.
- `editCalendarDefinition.jsp` — pass settings to the role-param row template (the JSP that errored at the screenshot below isn't this one, but the fix is uniform).

## Verification

uPortal-start Playwright spec `tests/ux/portlets/calendar.spec.ts` gets a new regression guard: \"event list renders without leaking Underscore template sigils\". Asserts the `.upcal-event-list` does not contain the substring `<%`. Fails before this PR, passes after redeploying `CalendarPortlet`.

Visual confirmation: the events column now shows the expected \"No events\" alert (or the populated day list) instead of raw template text.

## Notes

- The same root cause was the bug — every site emits `<% %>` regex literals through the same EL escape (`${\"<%\"}`/`${\"%>\"}`) precisely because JSP cannot tolerate raw `<%` in the source. I made the same mistake mid-fix and got JspException immediately, which is how I traced the EL-escape pattern back into `scripts.jsp`.
- I also considered putting the settings object in `calendar.js` (`upcal.tplSettings`) so the JSPs would pull it from the compiled JS bundle. Decided against — `scripts.jsp` already runs per-portlet-instance and namespaces under `${n}`, which keeps the override scoped without leaking into other portlets that load this WAR.