### PR TITLE
chore(deps): drop resource-server-content overlay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,12 +333,6 @@
         </dependency>
         <dependency>
             <groupId>org.jasig.resourceserver</groupId>
-            <artifactId>resource-server-content</artifactId>
-            <version>${resource-server.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.jasig.resourceserver</groupId>
             <artifactId>resource-server-utils</artifactId>
             <version>${resource-server.version}</version>
             <exclusions>
@@ -788,24 +782,6 @@
                     <attachClasses>true</attachClasses>
                     <warName>CalendarPortlet</warName>
                     <webXml>${basedir}/src/main/webapp/WEB-INF/web.xml</webXml>
-                    <overlays>
-                        <overlay>
-                            <groupId>org.jasig.resourceserver</groupId>
-                            <artifactId>resource-server-content</artifactId>
-                            <includes>
-                                <include>rs/famfamfam/silk/1.3/add.png</include>
-                                <include>rs/famfamfam/silk/1.3/arrow_left.png</include>
-                                <include>rs/famfamfam/silk/1.3/arrow_right.png</include>
-                                <include>rs/famfamfam/silk/1.3/calendar*.png</include>
-                                <include>rs/famfamfam/silk/1.3/cross.png</include>
-                                <include>rs/famfamfam/silk/1.3/page_edit.png</include>
-                                <include>rs/famfamfam/silk/1.3/page_white_put.png</include>
-                                <include>rs/famfamfam/silk/1.3/tick.png</include>
-                                <include>rs/backbone/1.3.3/</include>
-                                <include>rs/underscore/1.8.3/</include>
-                            </includes>
-                        </overlay>
-                    </overlays>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
## Summary

Drops the `resource-server-content` WAR overlay from `CalendarPortlet`. The overlay was unpacking lodash 4.17.4 (4 CVEs), modernizr, normalize, and a stack of jquery-plugins into the WAR for nothing — none of which any source file references — plus an explicit maven-war-plugin extract of 9 famfamfam silk PNGs (also unreferenced) and `rs/backbone/1.3.3/` + `rs/underscore/1.8.3/` (loaded by uPortal core's chrome from `/resource-server/rs/...`, not from this WAR's paths).

## Why this is safe

- `grep -rEn '/CalendarPortlet/rs/' src/` returns no matches → no JSP/JS/CSS in this portlet ever referenced the WAR-local `/CalendarPortlet/rs/...` paths.
- `_` and `Backbone` ARE used (calendarNarrowView, calendarWideView, editCalendarDefinition, scripts/calendar.js) but the symbols come from uPortal core's chrome via `common_skin.xml`, which serves them from `/resource-server/rs/...`. Drop here is invisible.
- The 9 famfamfam silk PNGs the maven-war-plugin extracted are not referenced anywhere in source.

## Test plan

- [ ] `mvn clean install -DskipTests` builds (verified locally on Java 11)
- [ ] WAR has no `rs/` directory (verified)
- [ ] Smoke: `/p/calendar/max/render.uP` renders normal + edit views without missing-resource errors. Underscore template + Backbone view both rely on uPortal-core-loaded scripts.