### PR TITLE
fix(json): register JodaModule on the JSON view's ObjectMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jasig.cas.client</groupId>
             <artifactId>cas-client-core</artifactId>
             <version>${cas.version}</version>

--- a/src/main/resources/context/views.xml
+++ b/src/main/resources/context/views.xml
@@ -25,11 +25,25 @@
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
+    <!-- Jackson ObjectMapper with JodaModule registered so org.joda.time
+         types (CalendarDisplayEvent.dayStart, dayEnd, etc.) serialize to
+         JSON instead of failing with InvalidDefinitionException. The
+         default ObjectMapper Spring would otherwise hand the JSON view
+         has no Joda support out of the box. -->
+    <bean id="jacksonObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper">
+        <property name="modules">
+            <list>
+                <bean class="com.fasterxml.jackson.datatype.joda.JodaModule"/>
+            </list>
+        </property>
+    </bean>
+
     <!-- JSON data view -->
-    <bean name="json" 
+    <bean name="json"
         class="org.springframework.web.servlet.view.json.MappingJackson2JsonView"
           p:contentType="application/json"
-          p:disableCaching="false"/>
+          p:disableCaching="false"
+          p:objectMapper-ref="jacksonObjectMapper"/>
 
     <!-- Empty view -->
     <bean name="empty" 

--- a/src/main/resources/context/views.xml
+++ b/src/main/resources/context/views.xml
@@ -27,16 +27,14 @@
 
     <!-- Jackson ObjectMapper with JodaModule registered so org.joda.time
          types (CalendarDisplayEvent.dayStart, dayEnd, etc.) serialize to
-         JSON instead of failing with InvalidDefinitionException. The
-         default ObjectMapper Spring would otherwise hand the JSON view
-         has no Joda support out of the box. -->
-    <bean id="jacksonObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper">
-        <property name="modules">
-            <list>
-                <bean class="com.fasterxml.jackson.datatype.joda.JodaModule"/>
-            </list>
-        </property>
-    </bean>
+         JSON instead of failing with InvalidDefinitionException. We use
+         Spring's Jackson2ObjectMapperFactoryBean (the plain ObjectMapper
+         has no `modules` setter) and let the SPI service loader pick up
+         every Jackson module on the classpath. jackson-datatype-joda
+         registers itself this way, so adding the dep is enough. -->
+    <bean id="jacksonObjectMapper"
+          class="org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean"
+          p:findModulesViaServiceLoader="true"/>
 
     <!-- JSON data view -->
     <bean name="json"


### PR DESCRIPTION
## Summary

Add `jackson-datatype-joda` and register `JodaModule` on the JSON view's ObjectMapper so the calendar resource endpoint can serialize `org.joda.time.DateTime` fields (e.g. `CalendarDisplayEvent.dayStart`).

## Problem

Without the module, every non-empty events response failed with:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException:
  Joda date/time type `org.joda.time.DateTime` not supported by default
```

The portlet's resource URL returned HTTP 500 for *every* configured calendar (including the bundled holiday calendar). The narrow view's `calendar.js` has only an `$.ajax` success handler with no error path, so on 500 the loading spinner never cleared and the UI hung on "Loading…".

## Changes

1. Add `com.fasterxml.jackson.datatype:jackson-datatype-joda` to `pom.xml`, pinned to `${jackson.version}` so it tracks the rest of the Jackson stack.
2. Wire a `Jackson2ObjectMapperFactoryBean` with `findModulesViaServiceLoader="true"` in `views.xml` and reference it from the JSON view's `objectMapper` property. The SPI service-loader entry that ships in `jackson-datatype-joda` makes registration automatic.

## Test plan

- [ ] `mvn install` in CalendarPortlet, then `./gradlew :overlays:CalendarPortlet:tomcatDeploy` in uPortal-start
- [ ] Configure the bundled holiday calendar, confirm events render in the narrow view
- [ ] Confirm `.gradle/tomcat/logs/calendar.log` no longer shows `InvalidDefinitionException` for `DateTime` serialization