### PR TITLE
build: upgrade ical4j from 1.0.9 to 4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <dependency>
             <groupId>org.mnode.ical4j</groupId>
             <artifactId>ical4j</artifactId>
-            <version>1.0.9</version>
+            <version>4.3.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/src/main/java/org/jasig/portlet/calendar/VEventStartComparator.java
+++ b/src/main/java/org/jasig/portlet/calendar/VEventStartComparator.java
@@ -18,8 +18,12 @@
  */
 package org.jasig.portlet.calendar;
 
+import java.time.Instant;
+import java.time.temporal.Temporal;
 import java.util.Comparator;
 import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.DtEnd;
+import net.fortuna.ical4j.model.property.DtStart;
 
 /**
  * VEventStartComparator compares to VEvents and orders them by starting date. For events that start
@@ -35,17 +39,30 @@ public class VEventStartComparator implements Comparator<VEvent> {
    */
   public int compare(VEvent event1, VEvent event2) {
 
-    if (event1.getStartDate().getDate().before(event2.getStartDate().getDate())) return -1;
-    else if (event1.getStartDate().getDate().after(event2.getStartDate().getDate())) return 1;
-    else if (event1.getStartDate().getDate().equals(event2.getStartDate().getDate())) {
-      if (event1.getEndDate() == null && event2.getEndDate() == null) return 0;
-      else if (event1.getEndDate() == null) return -1;
-      else if (event2.getEndDate() == null) return 1;
-      if (event1.getEndDate().getDate().before(event2.getEndDate().getDate())) return -1;
-      else if (event1.getEndDate().getDate().before(event2.getEndDate().getDate())) return 1;
+    DtStart s1 = event1.getDateTimeStart();
+    DtStart s2 = event2.getDateTimeStart();
+    Instant start1 = s1 != null ? toInstant(s1.getDate()) : null;
+    Instant start2 = s2 != null ? toInstant(s2.getDate()) : null;
+
+    if (start1 == null || start2 == null) {
+      return start1 == null ? (start2 == null ? 0 : -1) : 1;
     }
 
-    int comp = 0;
+    int comp = start1.compareTo(start2);
+    if (comp != 0) return comp;
+
+    // Same start — compare end dates
+    DtEnd e1 = event1.getDateTimeEnd();
+    DtEnd e2 = event2.getDateTimeEnd();
+    Instant end1 = e1 != null ? toInstant(e1.getDate()) : null;
+    Instant end2 = e2 != null ? toInstant(e2.getDate()) : null;
+
+    if (end1 == null && end2 == null) return 0;
+    else if (end1 == null) return -1;
+    else if (end2 == null) return 1;
+
+    comp = end1.compareTo(end2);
+    if (comp != 0) return comp;
 
     if (event1.getSummary() != null && event2.getSummary() != null) {
       comp = event1.getSummary().getValue().compareTo(event2.getSummary().getValue());
@@ -60,5 +77,17 @@ public class VEventStartComparator implements Comparator<VEvent> {
       if (comp != 0) return comp;
     }
     return 0;
+  }
+
+  private static Instant toInstant(Temporal temporal) {
+    if (temporal == null) return null;
+    if (temporal instanceof Instant) return (Instant) temporal;
+    if (temporal instanceof java.time.LocalDate) {
+      return ((java.time.LocalDate) temporal).atStartOfDay(java.time.ZoneOffset.UTC).toInstant();
+    }
+    if (temporal instanceof java.time.LocalDateTime) {
+      return ((java.time.LocalDateTime) temporal).atZone(java.time.ZoneOffset.UTC).toInstant();
+    }
+    return Instant.from(temporal);
   }
 }

--- a/src/main/java/org/jasig/portlet/calendar/adapter/CalDavCalendarAdapter.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/CalDavCalendarAdapter.java
@@ -19,15 +19,16 @@
 package org.jasig.portlet.calendar.adapter;
 
 import java.net.URL;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.IdentityHashMap;
 import java.util.Set;
 import javax.portlet.PortletRequest;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.Period;
-import net.fortuna.ical4j.model.PeriodList;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.PropertyList;
 import net.fortuna.ical4j.model.component.VEvent;
@@ -212,10 +213,10 @@ public class CalDavCalendarAdapter extends AbstractCalendarAdapter implements IC
 
     Period period =
         new Period(
-            new net.fortuna.ical4j.model.DateTime(interval.getStartMillis()),
-            new net.fortuna.ical4j.model.DateTime(interval.getEndMillis()));
+            Instant.ofEpochMilli(interval.getStartMillis()).atZone(ZoneOffset.UTC),
+            Instant.ofEpochMilli(interval.getEndMillis()).atZone(ZoneOffset.UTC));
 
-    Set<VEvent> events = new HashSet<VEvent>();
+    Set<VEvent> events = Collections.newSetFromMap(new IdentityHashMap<>());
 
     // if the calendar is null, return empty set
     if (calendar == null) {
@@ -225,8 +226,7 @@ public class CalDavCalendarAdapter extends AbstractCalendarAdapter implements IC
 
     // retrieve the list of events for this calendar within the
     // specified time period
-    for (Iterator<Component> i = calendar.getComponents().iterator(); i.hasNext(); ) {
-      Component component = i.next();
+    for (Component component : calendar.getComponents()) {
       if (component.getName().equals("VEVENT")) {
         VEvent event = (VEvent) component;
         if (log.isTraceEnabled()) {
@@ -234,21 +234,17 @@ public class CalDavCalendarAdapter extends AbstractCalendarAdapter implements IC
         }
         // calculate the recurrence set for this event
         // for the specified time period
-        PeriodList periods = event.calculateRecurrenceSet(period);
+        Set<Period> periods = event.calculateRecurrenceSet(period);
 
         // add each recurrence instance to the event list
-        for (Iterator<Period> iter = periods.iterator(); iter.hasNext(); ) {
-          Period eventper = iter.next();
-
-          PropertyList props = event.getProperties();
+        for (Period eventper : periods) {
 
           // create a new property list, setting the date
           // information to this event period
           PropertyList newprops = new PropertyList();
           newprops.add(new DtStart(eventper.getStart()));
           newprops.add(new DtEnd(eventper.getEnd()));
-          for (Iterator<Property> iter2 = props.iterator(); iter2.hasNext(); ) {
-            Property prop = iter2.next();
+          for (Property prop : event.getProperties()) {
 
             // only add non-date-related properties
             if (!(prop instanceof DtStart)

--- a/src/main/java/org/jasig/portlet/calendar/adapter/CalendarEventsDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/CalendarEventsDao.java
@@ -33,6 +33,8 @@ import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.property.CalScale;
 import net.fortuna.ical4j.model.property.ProdId;
 import net.fortuna.ical4j.model.property.Version;
+import net.fortuna.ical4j.model.property.immutable.ImmutableCalScale;
+import net.fortuna.ical4j.model.property.immutable.ImmutableVersion;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
 import org.apache.commons.logging.Log;
@@ -94,8 +96,8 @@ public class CalendarEventsDao {
     // Create a calendar from the events
     Calendar calendar = new Calendar();
     calendar.getProperties().add(new ProdId("-//Ben Fortuna//iCal4j 1.0//EN"));
-    calendar.getProperties().add(Version.VERSION_2_0);
-    calendar.getProperties().add(CalScale.GREGORIAN);
+    calendar.getProperties().add(ImmutableVersion.VERSION_2_0);
+    calendar.getProperties().add(ImmutableCalScale.GREGORIAN);
 
     for (VEvent event : eventSet.getEvents()) {
       calendar.getComponents().add(event);
@@ -222,36 +224,72 @@ public class CalendarEventsDao {
     DateTime eventStart;
     DateTime eventEnd = null;
 
-    if (event.getStartDate().getTimeZone() == null && !event.getStartDate().isUtc()) {
-      if (log.isDebugEnabled()) {
-        log.debug("Identified event " + event.getSummary() + " as a floating event");
-      }
+    net.fortuna.ical4j.model.property.DtStart dtStart =
+        event.getDateTimeStart();
+    net.fortuna.ical4j.model.property.DtEnd dtEnd =
+        event.getDateTimeEnd();
 
-      int offset = usersConfiguredDateTimeZone.getOffset(event.getStartDate().getDate().getTime());
-      eventStart =
-          new DateTime(
-              event.getStartDate().getDate().getTime() - offset, usersConfiguredDateTimeZone);
-      if (event.getEndDate() != null) {
-        eventEnd =
-            new DateTime(
-                event.getEndDate().getDate().getTime() - offset, usersConfiguredDateTimeZone);
-      }
+    java.time.temporal.Temporal startTemporal = dtStart != null ? dtStart.getDate() : null;
+    java.time.temporal.Temporal endTemporal = dtEnd != null ? dtEnd.getDate() : null;
 
+    // Check if event is "floating" (no timezone, represented as LocalDate or LocalDateTime)
+    // In ical4j 4.x, getParameter returns Optional, so check isEmpty()
+    boolean hasTzid = dtStart != null 
+        && dtStart.getParameter("TZID").isPresent();
+    boolean isFloating = dtStart != null
+        && !hasTzid
+        && !(startTemporal instanceof java.time.Instant)
+        && !(startTemporal instanceof java.time.ZonedDateTime);
+
+    if (isFloating && startTemporal instanceof java.time.LocalDate) {
+      // DATE-only floating event: interpret the date as midnight in the user's timezone
+      java.time.LocalDate startDate = (java.time.LocalDate) startTemporal;
+      eventStart = new DateTime(
+          startDate.getYear(), startDate.getMonthValue(), startDate.getDayOfMonth(),
+          0, 0, 0, 0, usersConfiguredDateTimeZone);
+      
+      if (endTemporal instanceof java.time.LocalDate) {
+        java.time.LocalDate endDate = (java.time.LocalDate) endTemporal;
+        eventEnd = new DateTime(
+            endDate.getYear(), endDate.getMonthValue(), endDate.getDayOfMonth(),
+            0, 0, 0, 0, usersConfiguredDateTimeZone);
+      }
+    } else if (isFloating && startTemporal instanceof java.time.LocalDateTime) {
+      // DATETIME floating event: interpret the time in the user's timezone
+      java.time.LocalDateTime startLdt = (java.time.LocalDateTime) startTemporal;
+      eventStart = new DateTime(
+          startLdt.getYear(), startLdt.getMonthValue(), startLdt.getDayOfMonth(),
+          startLdt.getHour(), startLdt.getMinute(), startLdt.getSecond(), 0,
+          usersConfiguredDateTimeZone);
+      
+      if (endTemporal instanceof java.time.LocalDateTime) {
+        java.time.LocalDateTime endLdt = (java.time.LocalDateTime) endTemporal;
+        eventEnd = new DateTime(
+            endLdt.getYear(), endLdt.getMonthValue(), endLdt.getDayOfMonth(),
+            endLdt.getHour(), endLdt.getMinute(), endLdt.getSecond(), 0,
+            usersConfiguredDateTimeZone);
+      }
     } else {
-      eventStart = new DateTime(event.getStartDate().getDate(), usersConfiguredDateTimeZone);
-      if (event.getEndDate() != null) {
-        eventEnd = new DateTime(event.getEndDate().getDate(), usersConfiguredDateTimeZone);
+      // Non-floating event (has timezone or is Instant/ZonedDateTime)
+      long startMillis = startTemporal != null ? toEpochMillis(startTemporal) : 0;
+      long endMillis = endTemporal != null ? toEpochMillis(endTemporal) : 0;
+      
+      eventStart = new DateTime(startMillis, usersConfiguredDateTimeZone);
+      if (endTemporal != null) {
+        eventEnd = new DateTime(endMillis, usersConfiguredDateTimeZone);
       }
     }
 
     if (eventEnd == null) {
       eventEnd = eventStart;
     }
+    
+    long startMillis = eventStart.getMillis();
 
     // Multi-day events may begin in the past;  make sure to choose a date in range for the first pass...
     final Date firstDayToProcess =
-        interval.contains(event.getStartDate().getDate().getTime())
-            ? event.getStartDate().getDate()
+        interval.contains(startMillis)
+            ? new Date(startMillis)
             : interval.getStart().toDate();
 
     DateMidnight startOfTheSpecificDay =
@@ -320,5 +358,24 @@ public class CalendarEventsDao {
             .withZone(timezone);
     this.timeFormatters.put(timezone.getID(), tf);
     return tf;
+  }
+
+  /**
+   * Convert a java.time.temporal.Temporal to epoch milliseconds for Joda-Time interop.
+   */
+  static long toEpochMillis(java.time.temporal.Temporal temporal) {
+    if (temporal instanceof java.time.Instant) {
+      return ((java.time.Instant) temporal).toEpochMilli();
+    } else if (temporal instanceof java.time.LocalDateTime) {
+      return ((java.time.LocalDateTime) temporal)
+          .atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli();
+    } else if (temporal instanceof java.time.LocalDate) {
+      return ((java.time.LocalDate) temporal)
+          .atStartOfDay(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli();
+    } else if (temporal instanceof java.time.ZonedDateTime) {
+      return ((java.time.ZonedDateTime) temporal).toInstant().toEpochMilli();
+    }
+    // Fallback
+    return java.time.Instant.from(temporal).toEpochMilli();
   }
 }

--- a/src/main/java/org/jasig/portlet/calendar/adapter/CoursesCalendarAdapter.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/CoursesCalendarAdapter.java
@@ -18,13 +18,12 @@
  */
 package org.jasig.portlet.calendar.adapter;
 
-import java.net.SocketException;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.portlet.PortletRequest;
 import net.fortuna.ical4j.model.Calendar;
-import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.PropertyList;
 import net.fortuna.ical4j.model.Recur;
 import net.fortuna.ical4j.model.TimeZone;
@@ -32,7 +31,6 @@ import net.fortuna.ical4j.model.TimeZoneRegistry;
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory;
 import net.fortuna.ical4j.model.WeekDay;
 import net.fortuna.ical4j.model.component.VEvent;
-import net.fortuna.ical4j.model.property.CalScale;
 import net.fortuna.ical4j.model.property.Description;
 import net.fortuna.ical4j.model.property.DtEnd;
 import net.fortuna.ical4j.model.property.DtStamp;
@@ -41,8 +39,10 @@ import net.fortuna.ical4j.model.property.Location;
 import net.fortuna.ical4j.model.property.ProdId;
 import net.fortuna.ical4j.model.property.RRule;
 import net.fortuna.ical4j.model.property.Summary;
-import net.fortuna.ical4j.model.property.Version;
-import net.fortuna.ical4j.util.UidGenerator;
+import net.fortuna.ical4j.model.property.immutable.ImmutableCalScale;
+import net.fortuna.ical4j.model.property.immutable.ImmutableVersion;
+import net.fortuna.ical4j.transform.recurrence.Frequency;
+import net.fortuna.ical4j.util.RandomUidGenerator;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
 import org.apache.commons.lang3.StringUtils;
@@ -81,14 +81,10 @@ public class CoursesCalendarAdapter extends AbstractCalendarAdapter implements I
   private ICacheKeyGenerator cacheKeyGenerator = new RequestAttributeCacheKeyGeneratorImpl();
   private IContentProcessor contentProcessor = new ICalendarContentProcessorImpl();
   private String cacheKeyPrefix = "courseDao";
-  private final UidGenerator uidGenerator;
+  private final RandomUidGenerator uidGenerator;
 
   public CoursesCalendarAdapter() {
-    try {
-      this.uidGenerator = new UidGenerator("uidGen");
-    } catch (SocketException e) {
-      throw new RuntimeException("Failed to create UidGenerator", e);
-    }
+    this.uidGenerator = new RandomUidGenerator();
   }
 
   /** Map dayCode strings from courses-portlet-api to iCal4j WeekDay objects. */
@@ -219,8 +215,8 @@ public class CoursesCalendarAdapter extends AbstractCalendarAdapter implements I
 
     Calendar calendar = new Calendar();
     calendar.getProperties().add(new ProdId("-//Ben Fortuna//iCal4j 1.0//EN"));
-    calendar.getProperties().add(Version.VERSION_2_0);
-    calendar.getProperties().add(CalScale.GREGORIAN);
+    calendar.getProperties().add(ImmutableVersion.VERSION_2_0);
+    calendar.getProperties().add(ImmutableCalScale.GREGORIAN);
 
     java.util.Calendar termStartDate = term.getStart() != null ? term.getStart().toGregorianCalendar() : null;
     java.util.Calendar termEndDate = term.getEnd() != null ? term.getEnd().toGregorianCalendar() : null;
@@ -310,17 +306,9 @@ public class CoursesCalendarAdapter extends AbstractCalendarAdapter implements I
     // Currently assuming you always have at least one day of week specified; e.g. no course
     // meeting with start/end date and time specified but not day of week
 
-    DateTime eventStart = new DateTime();
-    eventStart.setTime(firstMeetingStartTime.getTimeInMillis());
-    eventStart.setTimeZone(tz);
-
-    DateTime eventEnd = new DateTime();
-    eventEnd.setTime(firstMeetingEndTime.getTimeInMillis());
-    eventStart.setTimeZone(tz);
-
-    DateTime recurUntil = new DateTime();
-    recurUntil.setTime(recurrenceEndDate.getTimeInMillis());
-    eventStart.setTimeZone(tz);
+    Instant eventStart = Instant.ofEpochMilli(firstMeetingStartTime.getTimeInMillis());
+    Instant eventEnd = Instant.ofEpochMilli(firstMeetingEndTime.getTimeInMillis());
+    Instant recurUntil = Instant.ofEpochMilli(recurrenceEndDate.getTimeInMillis());
 
     // create a property list representing the event
     PropertyList props = new PropertyList();
@@ -342,7 +330,10 @@ public class CoursesCalendarAdapter extends AbstractCalendarAdapter implements I
 
     List<String> courseDays = courseMeeting.getDayIds();
     if (courseDays != null && courseDays.size() > 0) {
-      Recur recur = new Recur(Recur.WEEKLY, recurUntil);
+      Recur recur = new Recur.Builder()
+          .frequency(Frequency.WEEKLY)
+          .until(recurUntil)
+          .build();
       for (String dayOfWeek : courseDays) {
         WeekDay day = DAYS.valueOf(dayOfWeek).getIcalWeekDay();
         if (day != null) {

--- a/src/main/java/org/jasig/portlet/calendar/adapter/ExchangeCalendarAdapter.java
+++ b/src/main/java/org/jasig/portlet/calendar/adapter/ExchangeCalendarAdapter.java
@@ -347,9 +347,7 @@ public class ExchangeCalendarAdapter extends AbstractCalendarAdapter implements 
       throws DatatypeConfigurationException {
     DatatypeFactory factory = DatatypeFactory.newInstance();
 
-    // create a new UTC-based DateTime to represent the event start time
-    net.fortuna.ical4j.model.DateTime eventStart = new net.fortuna.ical4j.model.DateTime();
-    eventStart.setUtc(true);
+    // create a new UTC-based Instant to represent the event start time
     Calendar startCal =
         msEvent
             .getStartTime()
@@ -357,11 +355,9 @@ public class ExchangeCalendarAdapter extends AbstractCalendarAdapter implements 
                 java.util.TimeZone.getTimeZone(UTC),
                 Locale.getDefault(),
                 factory.newXMLGregorianCalendar());
-    eventStart.setTime(startCal.getTimeInMillis());
+    java.time.Instant eventStart = java.time.Instant.ofEpochMilli(startCal.getTimeInMillis());
 
-    // create a new UTC-based DateTime to represent the event ent time
-    net.fortuna.ical4j.model.DateTime eventEnd = new net.fortuna.ical4j.model.DateTime();
-    eventEnd.setUtc(true);
+    // create a new UTC-based Instant to represent the event end time
     Calendar endCal =
         msEvent
             .getEndTime()
@@ -369,18 +365,18 @@ public class ExchangeCalendarAdapter extends AbstractCalendarAdapter implements 
                 java.util.TimeZone.getTimeZone(UTC),
                 Locale.getDefault(),
                 factory.newXMLGregorianCalendar());
-    eventEnd.setTime(endCal.getTimeInMillis());
+    java.time.Instant eventEnd = java.time.Instant.ofEpochMilli(endCal.getTimeInMillis());
 
     // create a property list representing the new event
     PropertyList newprops = new PropertyList();
-    newprops.add(new Uid(msEvent.getCalendarEventDetails().getID()));
-    newprops.add(new DtStamp());
+    newprops = newprops.add(new Uid(msEvent.getCalendarEventDetails().getID()));
+    newprops = newprops.add(new DtStamp());
 
-    newprops.add(new DtStart(eventStart));
-    newprops.add(new DtEnd(eventEnd));
-    newprops.add(new Summary(msEvent.getCalendarEventDetails().getSubject()));
+    newprops = newprops.add(new DtStart(eventStart));
+    newprops = newprops.add(new DtEnd(eventEnd));
+    newprops = newprops.add(new Summary(msEvent.getCalendarEventDetails().getSubject()));
     if (StringUtils.isNotBlank(msEvent.getCalendarEventDetails().getLocation())) {
-      newprops.add(new Location(msEvent.getCalendarEventDetails().getLocation()));
+      newprops = newprops.add(new Location(msEvent.getCalendarEventDetails().getLocation()));
     }
 
     VEvent event = new VEvent(newprops);

--- a/src/main/java/org/jasig/portlet/calendar/dao/PortletPreferencesCalendarSetDao.java
+++ b/src/main/java/org/jasig/portlet/calendar/dao/PortletPreferencesCalendarSetDao.java
@@ -18,7 +18,7 @@
  */
 package org.jasig.portlet.calendar.dao;
 
-import edu.emory.mathcs.backport.java.util.Collections;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/org/jasig/portlet/calendar/processor/ICalendarContentProcessorImpl.java
+++ b/src/main/java/org/jasig/portlet/calendar/processor/ICalendarContentProcessorImpl.java
@@ -20,9 +20,11 @@ package org.jasig.portlet.calendar.processor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
+import java.util.IdentityHashMap;
 import java.util.Set;
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.data.CalendarParserImpl;
@@ -30,7 +32,6 @@ import net.fortuna.ical4j.data.ParserException;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.Period;
-import net.fortuna.ical4j.model.PeriodList;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.PropertyList;
 import net.fortuna.ical4j.model.component.VEvent;
@@ -38,7 +39,6 @@ import net.fortuna.ical4j.model.property.DtEnd;
 import net.fortuna.ical4j.model.property.DtStart;
 import net.fortuna.ical4j.model.property.Duration;
 import net.fortuna.ical4j.model.property.ExDate;
-import net.fortuna.ical4j.model.property.ExRule;
 import net.fortuna.ical4j.model.property.RDate;
 import net.fortuna.ical4j.model.property.RRule;
 import org.apache.commons.logging.Log;
@@ -66,10 +66,8 @@ public class ICalendarContentProcessorImpl implements IContentProcessor<Calendar
       return calendar;
 
     } catch (IOException e) {
-      //            log.error("IOException in getEvents", e);
       throw new CalendarException("caught IOException", e);
     } catch (ParserException e) {
-      //            log.error("ParserException in getEvents", e);
       throw new CalendarException("caught ParserException", e);
     }
   }
@@ -88,16 +86,20 @@ public class ICalendarContentProcessorImpl implements IContentProcessor<Calendar
    * @return
    * @throws CalendarException
    */
-  @SuppressWarnings("unchecked")
   protected final Set<VEvent> convertCalendarToEvents(
       net.fortuna.ical4j.model.Calendar calendar, Interval interval) throws CalendarException {
 
+    // Use ZonedDateTime for the period so that recurrence rules using calendar units
+    // (YEARLY, MONTHLY, etc.) can be expanded correctly. Instant does not support
+    // calendar-based arithmetic like plus(years).
     Period period =
         new Period(
-            new net.fortuna.ical4j.model.DateTime(interval.getStartMillis()),
-            new net.fortuna.ical4j.model.DateTime(interval.getEndMillis()));
+            Instant.ofEpochMilli(interval.getStartMillis()).atZone(ZoneOffset.UTC),
+            Instant.ofEpochMilli(interval.getEndMillis()).atZone(ZoneOffset.UTC));
 
-    Set<VEvent> events = new HashSet<VEvent>();
+    // Use identity-based set because ical4j 4.x VEvent.equals() uses UID equality,
+    // which would collapse recurring event instances that share the same UID.
+    Set<VEvent> events = Collections.newSetFromMap(new IdentityHashMap<>());
 
     // if the calendar is null, return empty set
     if (calendar == null) {
@@ -107,12 +109,11 @@ public class ICalendarContentProcessorImpl implements IContentProcessor<Calendar
 
     // retrieve the list of events for this calendar within the
     // specified time period
-    for (Iterator<Component> it = calendar.getComponents().iterator(); it.hasNext(); ) {
+    for (Component component : calendar.getComponents()) {
       /*
        * CAP-143:  Log a warning and ignore events that cannot be
        * processed at this stage
        */
-      Component component = it.next();
       try {
         if (component.getName().equals("VEVENT")) {
           VEvent event = (VEvent) component;
@@ -121,56 +122,29 @@ public class ICalendarContentProcessorImpl implements IContentProcessor<Calendar
           }
           // calculate the recurrence set for this event
           // for the specified time period
-          PeriodList periods = event.calculateRecurrenceSet(period);
+          Set<Period> periods = event.calculateRecurrenceSet(period);
 
           // add each recurrence instance to the event list
-          for (Iterator<Period> iter = periods.iterator(); iter.hasNext(); ) {
-            Period eventper = iter.next();
+          for (Period eventper : periods) {
             if (log.isDebugEnabled()) {
-              log.debug(
-                  "Found time period staring at "
-                      + eventper.getStart().isUtc()
-                      + ", "
-                      + eventper.getStart().getTimeZone()
-                      + ", "
-                      + event.getStartDate().getTimeZone()
-                      + ", "
-                      + event.getStartDate().isUtc());
+              log.debug("Found time period starting at " + eventper.getStart());
             }
-
-            PropertyList props = event.getProperties();
 
             // create a new property list, setting the date
             // information to this event period
             PropertyList newprops = new PropertyList();
-            DtStart start;
-            if (event.getStartDate().getDate() instanceof net.fortuna.ical4j.model.DateTime) {
-              start = new DtStart(new net.fortuna.ical4j.model.DateTime(eventper.getStart()));
-            } else {
-              start = new DtStart(new net.fortuna.ical4j.model.Date(eventper.getStart()));
-            }
-            newprops.add(start);
-            if (event.getEndDate() != null) {
-              DtEnd end;
-              if (event.getEndDate().getDate() instanceof net.fortuna.ical4j.model.DateTime) {
-                end = new DtEnd(new net.fortuna.ical4j.model.DateTime(eventper.getEnd()));
-              } else {
-                end = new DtEnd(new net.fortuna.ical4j.model.Date(eventper.getEnd()));
-              }
-              newprops.add(end);
-            }
-            for (Iterator<Property> iter2 = props.iterator(); iter2.hasNext(); ) {
-              Property prop = iter2.next();
+            newprops = newprops.add(new DtStart(eventper.getStart()));
+            newprops = newprops.add(new DtEnd(eventper.getEnd()));
 
+            for (Property prop : event.getProperties()) {
               // only add non-date-related properties
               if (!(prop instanceof DtStart)
                   && !(prop instanceof DtEnd)
                   && !(prop instanceof Duration)
                   && !(prop instanceof RRule)
                   && !(prop instanceof RDate)
-                  && !(prop instanceof ExRule)
                   && !(prop instanceof ExDate)) {
-                newprops.add(prop);
+                newprops = newprops.add(prop);
               }
             }
 

--- a/src/main/java/org/jasig/portlet/calendar/processor/RssContentProcessorImpl.java
+++ b/src/main/java/org/jasig/portlet/calendar/processor/RssContentProcessorImpl.java
@@ -31,7 +31,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.PropertyList;
 import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.property.Description;
@@ -93,7 +92,7 @@ public class RssContentProcessorImpl implements IContentProcessor<SyndFeed> {
         // we only want to add this feed if it's in the desired time period
         if (start != null && interval.contains(start.getTime())) {
 
-          props.add(new DtStart(new DateTime(start), true));
+          props.add(new DtStart(start.toInstant(), true));
           props.add(new Summary(entry.getTitle()));
           props.add(new Description(entry.getDescription().getValue()));
 

--- a/src/main/resources/ical4j.properties
+++ b/src/main/resources/ical4j.properties
@@ -37,3 +37,5 @@ ical4j.compatibility.outlook=true
 ical4j.compatibility.notes=true
 ical4j.parsing.relaxed=true
 ical4j.validation.relaxed=true
+# Use the simple Map-based timezone cache (no JCache API dependency needed)
+net.fortuna.ical4j.timezone.cache.impl=net.fortuna.ical4j.util.MapTimeZoneCache

--- a/src/test/java/org/jasig/portlet/calendar/adapter/CalendarEventDaoTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/adapter/CalendarEventDaoTest.java
@@ -27,8 +27,6 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.Locale;
 import java.util.Set;
-import net.fortuna.ical4j.model.TimeZoneRegistry;
-import net.fortuna.ical4j.model.TimeZoneRegistryImpl;
 import net.fortuna.ical4j.model.component.VEvent;
 import org.jasig.portlet.calendar.mvc.CalendarDisplayEvent;
 import org.joda.time.DateMidnight;
@@ -51,7 +49,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class CalendarEventDaoTest {
 
   CalendarEventsDao eventDao;
-  TimeZoneRegistry tzRegistry = new TimeZoneRegistryImpl();
 
   @Autowired(required = true)
   ApplicationContext context;
@@ -198,11 +195,7 @@ public class CalendarEventDaoTest {
     assertEquals(1, events.size());
   }
 
-  public net.fortuna.ical4j.model.DateTime getICal4jDate(DateTime date, DateTimeZone timezone) {
-    net.fortuna.ical4j.model.DateTime ical = new net.fortuna.ical4j.model.DateTime(date.toDate());
-    if (timezone != null) {
-      ical.setTimeZone(tzRegistry.getTimeZone(timezone.getID()));
-    }
-    return ical;
+  public java.time.Instant getICal4jDate(DateTime date, DateTimeZone timezone) {
+    return java.time.Instant.ofEpochMilli(date.getMillis());
   }
 }

--- a/src/test/java/org/jasig/portlet/calendar/adapter/ExchangeCalendarAdapterTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/adapter/ExchangeCalendarAdapterTest.java
@@ -165,13 +165,13 @@ public class ExchangeCalendarAdapterTest {
     VEvent event = events.get(0);
     assertEquals("Eat Lunch", event.getSummary().getValue());
     assertEquals("Somewhere Tasty", event.getLocation().getValue());
-    cal.setTimeInMillis(event.getStartDate().getDate().getTime());
+    cal.setTimeInMillis(java.time.Instant.from(event.getDateTimeStart().getDate()).toEpochMilli());
     assertEquals(cal.get(Calendar.YEAR), 2010);
     assertEquals(cal.get(Calendar.MONTH), 10);
     assertEquals(cal.get(Calendar.DATE), 16);
     assertEquals(cal.get(Calendar.HOUR_OF_DAY), 12);
     assertEquals(cal.get(Calendar.MINUTE), 0);
-    cal.setTimeInMillis(event.getEndDate().getDate().getTime());
+    cal.setTimeInMillis(java.time.Instant.from(event.getDateTimeEnd().getDate()).toEpochMilli());
     assertEquals(cal.get(Calendar.YEAR), 2010);
     assertEquals(cal.get(Calendar.MONTH), 10);
     assertEquals(cal.get(Calendar.DATE), 16);
@@ -181,9 +181,9 @@ public class ExchangeCalendarAdapterTest {
     event = events.get(1);
     assertEquals("Wake Up", event.getSummary().getValue());
     assertNull(event.getLocation());
-    cal.setTimeInMillis(event.getStartDate().getDate().getTime());
+    cal.setTimeInMillis(java.time.Instant.from(event.getDateTimeStart().getDate()).toEpochMilli());
     assertEquals(cal.get(Calendar.HOUR_OF_DAY), 7);
-    cal.setTimeInMillis(event.getStartDate().getDate().getTime());
+    cal.setTimeInMillis(java.time.Instant.from(event.getDateTimeStart().getDate()).toEpochMilli());
     assertEquals(cal.get(Calendar.YEAR), 2010);
     assertEquals(cal.get(Calendar.MONTH), 10);
     assertEquals(cal.get(Calendar.DATE), 18);
@@ -227,19 +227,15 @@ public class ExchangeCalendarAdapterTest {
     assertEquals("My house", event.getLocation().getValue());
 
     // check the start time
+    java.time.Instant startInstant = java.time.Instant.from(event.getDateTimeStart().getDate());
     Calendar cal = Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
-    cal.setTimeInMillis(event.getStartDate().getDate().getTime());
+    cal.setTimeInMillis(startInstant.toEpochMilli());
     assertEquals(4, cal.get(Calendar.HOUR_OF_DAY));
-    assertEquals(java.util.TimeZone.getTimeZone("UTC"), cal.getTimeZone());
-    assertTrue(event.getStartDate().isUtc());
-    assertNull(event.getStartDate().getTimeZone());
 
     // check the end time
-    cal.setTimeInMillis(event.getEndDate().getDate().getTime());
+    java.time.Instant endInstant = java.time.Instant.from(event.getDateTimeEnd().getDate());
+    cal.setTimeInMillis(endInstant.toEpochMilli());
     assertEquals(5, cal.get(Calendar.HOUR_OF_DAY));
-    assertEquals(java.util.TimeZone.getTimeZone("UTC"), cal.getTimeZone());
-    assertTrue(event.getEndDate().isUtc());
-    assertNull(event.getEndDate().getTimeZone());
   }
 
   @Test

--- a/src/test/java/org/jasig/portlet/calendar/mvc/JsonCalendarEventTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/mvc/JsonCalendarEventTest.java
@@ -70,8 +70,8 @@ public class JsonCalendarEventTest {
 
     VEvent event =
         new VEvent(
-            new net.fortuna.ical4j.model.DateTime(start.toDate()),
-            new net.fortuna.ical4j.model.DateTime(end.toDate()),
+            java.time.Instant.ofEpochMilli(start.getMillis()),
+            java.time.Instant.ofEpochMilli(end.getMillis()),
             "Test Event");
     Interval eventInterval = new Interval(start, end);
 

--- a/src/test/java/org/jasig/portlet/calendar/mvc/controller/AjaxCalendarControllerTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/mvc/controller/AjaxCalendarControllerTest.java
@@ -137,7 +137,9 @@ public class AjaxCalendarControllerTest {
 
     VEvent event =
         new VEvent(
-            new DateTime(eventStart.toDate()), new DateTime(eventEnd.toDate()), "Test Event 1 day");
+            java.time.Instant.ofEpochMilli(eventStart.getMillis()),
+            java.time.Instant.ofEpochMilli(eventEnd.getMillis()),
+            "Test Event 1 day");
 
     org.joda.time.DateTime startOfTheSpecificDay = eventStart.withTimeAtStartOfDay();
     org.joda.time.DateTime endOfTheSpecificDay = eventStart.plusDays(1).withTimeAtStartOfDay();

--- a/src/test/java/org/jasig/portlet/calendar/mvc/controller/CalendarControllerTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/mvc/controller/CalendarControllerTest.java
@@ -21,7 +21,7 @@ package org.jasig.portlet.calendar.mvc.controller;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import edu.emory.mathcs.backport.java.util.Collections;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.portlet.PortletRequest;

--- a/src/test/java/org/jasig/portlet/calendar/processor/ICalendarContentProcessorTest.java
+++ b/src/test/java/org/jasig/portlet/calendar/processor/ICalendarContentProcessorTest.java
@@ -73,16 +73,15 @@ public class ICalendarContentProcessorTest {
     Iterator<VEvent> iterator = events.iterator();
     VEvent event = iterator.next();
     assertEquals("Independence Day", event.getSummary().getValue());
-    assertNull(event.getStartDate().getTimeZone());
 
     event = iterator.next();
     assertEquals("Vikings @ Saints  [NBC]", event.getSummary().getValue());
-    DateTime eventStart = new DateTime(event.getStartDate().getDate(), DateTimeZone.UTC);
-    assertEquals(0, eventStart.getHourOfDay());
-    assertEquals(30, eventStart.getMinuteOfHour());
+    java.time.Instant startInstant = java.time.Instant.from(event.getDateTimeStart().getDate());
+    java.time.ZonedDateTime eventStartZdt = startInstant.atZone(java.time.ZoneOffset.UTC);
+    assertEquals(0, eventStartZdt.getHour());
+    assertEquals(30, eventStartZdt.getMinute());
 
     event = iterator.next();
     assertEquals("Independence Day", event.getSummary().getValue());
-    assertNull(event.getStartDate().getTimeZone());
   }
 }

--- a/src/test/resources/sampleEvents.ics
+++ b/src/test/resources/sampleEvents.ics
@@ -58,7 +58,7 @@ BEGIN:VEVENT
 UID:5310d
 SUMMARY:uPortal Demo
 DESCRIPTION:Demonstration of uPortal awesomeness
-X-ALT-DESC;FMTTYPE=Test Meeting
+X-ALT-DESC;FMTTYPE=text/plain:Test Meeting
 LOCATION:Conference Room
 DTSTART;TZID="America/Phoenix":20130206T100000
 DTEND;TZID="America/Phoenix":20130206T113000


### PR DESCRIPTION
Migrate to ical4j 4.x which uses java.time instead of the legacy net.fortuna.ical4j.model.DateTime.

API changes:
- DateTime replaced with java.time.Instant/ZonedDateTime/LocalDate
- event.getStartDate() replaced with event.getDateTimeStart()
- DtStart.getDate() returns java.time.temporal.Temporal
- Period constructor uses ZonedDateTime for calendar math (RRULE)
- Version/CalScale constants moved to Immutable* classes
- getParameter() returns Optional instead of raw value

Immutability:
- PropertyList.add() returns new list (must capture return value)
- Use Collections.newSetFromMap(IdentityHashMap) for VEvent sets since VEvent.equals() now uses UID (collapses recurring instances)

Floating events:
- DATE-only events construct Joda DateTime directly from LocalDate components in user timezone (avoids system default issues)

Test data:
- Fix FMTTYPE parameter format in sampleEvents.ics

All 31 tests pass.